### PR TITLE
Slack event structure

### DIFF
--- a/Sources/SlackBlockKit/BlockElements/UtilTypes/BlockElement.swift
+++ b/Sources/SlackBlockKit/BlockElements/UtilTypes/BlockElement.swift
@@ -5,81 +5,72 @@ public protocol BlockElement: Codable {
     var type: String { get }
 }
 
-public func isEqual(lhs: BlockElement?, rhs: BlockElement?) -> Bool {
-    switch lhs {
-    case .none:
-        switch rhs {
-        case .none: return true
-        case .some: return false
+public extension BlockElement {
+    func isEqual(to rhs: BlockElement?) -> Bool {
+        let lhs = self
+        guard let rhs = rhs else { return false }
+        
+        switch Swift.type(of: lhs).type {
+        case .button:
+            guard let lhs = lhs as? ButtonElement, let rhs = rhs as? ButtonElement else { return false }
+            return lhs == rhs
+        case .checkboxes:
+            guard let lhs = lhs as? CheckboxGroups, let rhs = rhs as? CheckboxGroups else { return false }
+            return lhs == rhs
+        case .datepicker:
+            guard let lhs = lhs as? DatePickerElement, let rhs = rhs as? DatePickerElement else { return false }
+            return lhs == rhs
+        case .image:
+            guard let lhs = lhs as? ImageElement, let rhs = rhs as? ImageElement else { return false }
+            return lhs == rhs
+        case .multiConversationsSelect:
+            guard let lhs = lhs as? MultiSelectMenuConversationsList, let rhs = rhs as? MultiSelectMenuConversationsList else { return false }
+            return lhs == rhs
+        case .multiExternalSelect:
+            guard let lhs = lhs as? MultiSelectMenuExternalDataSource, let rhs = rhs as? MultiSelectMenuExternalDataSource else { return false }
+            return lhs == rhs
+        case .multiChannelsSelect:
+            guard let lhs = lhs as? MultiSelectMenuPublicChannelsList, let rhs = rhs as? MultiSelectMenuPublicChannelsList else { return false }
+            return lhs == rhs
+        case .multiStaticSelect:
+            guard let lhs = lhs as? MultiSelectMenuStaticOptions, let rhs = rhs as? MultiSelectMenuStaticOptions else { return false }
+            return lhs == rhs
+        case .multiUsersSelect:
+            guard let lhs = lhs as? MultiSelectMenuUserList, let rhs = rhs as? MultiSelectMenuUserList else { return false }
+            return lhs == rhs
+        case .overflow:
+            guard let lhs = lhs as? OverflowMenuElement, let rhs = rhs as? OverflowMenuElement else { return false }
+            return lhs == rhs
+        case .plainTextInput:
+            guard let lhs = lhs as? PlainTextInputElement, let rhs = rhs as? PlainTextInputElement else { return false }
+            return lhs == rhs
+        case .radioButtons:
+            guard let lhs = lhs as? RadioButtonGroupElement, let rhs = rhs as? RadioButtonGroupElement else { return false }
+            return lhs == rhs
+        case .conversationsSelect:
+            guard let lhs = lhs as? SelectMenuConversationsList, let rhs = rhs as? SelectMenuConversationsList else { return false }
+            return lhs == rhs
+        case .externalSelect:
+            guard let lhs = lhs as? SelectMenuExternalDataSource, let rhs = rhs as? SelectMenuExternalDataSource else { return false }
+            return lhs == rhs
+        case .channelsSelect:
+            guard let lhs = lhs as? SelectMenuPublicChannelsList, let rhs = rhs as? SelectMenuPublicChannelsList else { return false }
+            return lhs == rhs
+        case .staticSelect:
+            guard let lhs = lhs as? SelectMenuStaticOptions, let rhs = rhs as? SelectMenuStaticOptions else { return false }
+            return lhs == rhs
+        case .usersSelect:
+            guard let lhs = lhs as? SelectMenuUserList, let rhs = rhs as? SelectMenuUserList else { return false }
+            return lhs == rhs
+        case .timepicker:
+            guard let lhs = lhs as? TimePickerElement, let rhs = rhs as? TimePickerElement else { return false }
+            return lhs == rhs
+        case .plainText:
+            guard let lhs = lhs as? TextObject, let rhs = rhs as? TextObject else { return false }
+            return lhs == rhs
+        case .mrkdwn:
+            guard let lhs = lhs as? TextObject, let rhs = rhs as? TextObject else { return false }
+            return lhs == rhs
         }
-    case .some:
-        switch rhs {
-        case .none: return false
-        case .some: break
-        }
-    }
-    guard let lhs = lhs, let rhs = rhs else { return false }
-    
-    switch Swift.type(of: lhs).type {
-    case .button:
-        guard let lhs = lhs as? ButtonElement, let rhs = rhs as? ButtonElement else { return false }
-        return lhs == rhs
-    case .checkboxes:
-        guard let lhs = lhs as? CheckboxGroups, let rhs = rhs as? CheckboxGroups else { return false }
-        return lhs == rhs
-    case .datepicker:
-        guard let lhs = lhs as? DatePickerElement, let rhs = rhs as? DatePickerElement else { return false }
-        return lhs == rhs
-    case .image:
-        guard let lhs = lhs as? ImageElement, let rhs = rhs as? ImageElement else { return false }
-        return lhs == rhs
-    case .multiConversationsSelect:
-        guard let lhs = lhs as? MultiSelectMenuConversationsList, let rhs = rhs as? MultiSelectMenuConversationsList else { return false }
-        return lhs == rhs
-    case .multiExternalSelect:
-        guard let lhs = lhs as? MultiSelectMenuExternalDataSource, let rhs = rhs as? MultiSelectMenuExternalDataSource else { return false }
-        return lhs == rhs
-    case .multiChannelsSelect:
-        guard let lhs = lhs as? MultiSelectMenuPublicChannelsList, let rhs = rhs as? MultiSelectMenuPublicChannelsList else { return false }
-        return lhs == rhs
-    case .multiStaticSelect:
-        guard let lhs = lhs as? MultiSelectMenuStaticOptions, let rhs = rhs as? MultiSelectMenuStaticOptions else { return false }
-        return lhs == rhs
-    case .multiUsersSelect:
-        guard let lhs = lhs as? MultiSelectMenuUserList, let rhs = rhs as? MultiSelectMenuUserList else { return false }
-        return lhs == rhs
-    case .overflow:
-        guard let lhs = lhs as? OverflowMenuElement, let rhs = rhs as? OverflowMenuElement else { return false }
-        return lhs == rhs
-    case .plainTextInput:
-        guard let lhs = lhs as? PlainTextInputElement, let rhs = rhs as? PlainTextInputElement else { return false }
-        return lhs == rhs
-    case .radioButtons:
-        guard let lhs = lhs as? RadioButtonGroupElement, let rhs = rhs as? RadioButtonGroupElement else { return false }
-        return lhs == rhs
-    case .conversationsSelect:
-        guard let lhs = lhs as? SelectMenuConversationsList, let rhs = rhs as? SelectMenuConversationsList else { return false }
-        return lhs == rhs
-    case .externalSelect:
-        guard let lhs = lhs as? SelectMenuExternalDataSource, let rhs = rhs as? SelectMenuExternalDataSource else { return false }
-        return lhs == rhs
-    case .channelsSelect:
-        guard let lhs = lhs as? SelectMenuPublicChannelsList, let rhs = rhs as? SelectMenuPublicChannelsList else { return false }
-        return lhs == rhs
-    case .staticSelect:
-        guard let lhs = lhs as? SelectMenuStaticOptions, let rhs = rhs as? SelectMenuStaticOptions else { return false }
-        return lhs == rhs
-    case .usersSelect:
-        guard let lhs = lhs as? SelectMenuUserList, let rhs = rhs as? SelectMenuUserList else { return false }
-        return lhs == rhs
-    case .timepicker:
-        guard let lhs = lhs as? TimePickerElement, let rhs = rhs as? TimePickerElement else { return false }
-        return lhs == rhs
-    case .plainText:
-        guard let lhs = lhs as? TextObject, let rhs = rhs as? TextObject else { return false }
-        return lhs == rhs
-    case .mrkdwn:
-        guard let lhs = lhs as? TextObject, let rhs = rhs as? TextObject else { return false }
-        return lhs == rhs
     }
 }

--- a/Sources/SlackBlockKit/Events/AppHomeOpenedEvent.swift
+++ b/Sources/SlackBlockKit/Events/AppHomeOpenedEvent.swift
@@ -1,0 +1,4 @@
+public struct AppHomeOpenedEvent: SlackEvent {
+    public static let type: SlackEventType = .appHomeOpened
+    public let type: String
+}

--- a/Sources/SlackBlockKit/Events/AppHomeOpenedEvent.swift
+++ b/Sources/SlackBlockKit/Events/AppHomeOpenedEvent.swift
@@ -1,4 +1,43 @@
-public struct AppHomeOpenedEvent: SlackEvent {
+/// This app event notifies your app when a user has entered the App Home.
+public struct AppHomeOpenedEvent: SlackEvent, Equatable {
     public static let type: SlackEventType = .appHomeOpened
+    /// The type of event. In this case `type` is always `app_home_opened`.
     public let type: String
+    /// The user ID belonging to the user that incited this action. Not included in all events
+    /// as not all events are controlled by users. See the top-level callback object's
+    /// `authed_users` if you need to calculate event visibility by user.
+    public let user: String
+    /// The timestamp of the event. The combination of `event_ts`, `team_id`,
+    /// `user_id`, or `channel_id` is intended to be unique. This field is included
+    /// with every inner event type.
+    public let eventTs: String
+    /// If the user opens a tab within the App Home, the event payload for this event
+    /// will reference that in the `tab` field.
+    public let tab: String?
+    /// If they opened a Home tab and that tab has had a `view` published at least
+    /// once before, a `view` field will also be included. That `view` field will
+    /// contain the current state of the Home tab, including the list of `blocks`,
+    /// and various pieces of metadata.
+    public let view: HomeTabView?
+    
+    public init(
+        user: String,
+        eventTs: String,
+        tab: String? = nil,
+        view: HomeTabView? = nil
+    ) {
+        self.type = Self.type.rawValue
+        self.user = user
+        self.eventTs = eventTs
+        self.tab = tab
+        self.view = view
+    }
+    
+    public enum CodingKeys: String, CodingKey {
+        case type
+        case user
+        case eventTs = "event_ts"
+        case tab
+        case view
+    }
 }

--- a/Sources/SlackBlockKit/Events/SlackEventCallback.swift
+++ b/Sources/SlackBlockKit/Events/SlackEventCallback.swift
@@ -13,12 +13,6 @@ public struct SlackEventCallback: SlackEventWrapper {
     /// The unique identifier for the workspace/team where this event occurred.
     /// Example: `T461EG9ZZ`
     public let teamId: String
-    /// The unique identifier for the application this event is intended for. Your application's
-    /// ID can be found in the URL of the your application console. If your Request URL manages
-    /// multiple applications, use this field along with the `token` field to validate and route
-    /// incoming requests.
-    /// Example: `A4ZFV49KK`
-    public let apiAppId: String
     /// Contains the inner set of fields representing the event that's happening.
     public let event: SlackEvent
     /// A unique identifier for this specific event, globally unique across all workspaces.
@@ -41,25 +35,36 @@ public struct SlackEventCallback: SlackEventWrapper {
     /// `apps.event.authorizations.list` method to obtain a full list of installations of your app
     /// that this event is visible to.
     public let eventContext: String?
+    /// The unique identifier for the application this event is intended for. Your application's
+    /// ID can be found in the URL of the your application console. If your Request URL manages
+    /// multiple applications, use this field along with the `token` field to validate and route
+    /// incoming requests.
+    /// Example: `A4ZFV49KK`
+    public var apiAppId: String?
+    
+    // The following may also appear
+    public var isEnterpriseInstall: Bool?
+    public var responseUrls: [String]?
+    public var triggerId: String?
     
     public init(
         token: String,
         teamId: String,
-        apiAppId: String,
         event: SlackEvent,
         eventId: String,
         eventTime: Int,
-        authedUsers: [String]?,
-        authorizations: SlackAuthorizations?,
-        eventContext: String?
+        apiAppId: String? = nil,
+        authedUsers: [String]? = nil,
+        authorizations: SlackAuthorizations? = nil,
+        eventContext: String? = nil
     ) {
         self.type = Self.type.rawValue
         self.token = token
         self.teamId = teamId
-        self.apiAppId = apiAppId
         self.event = event
         self.eventId = eventId
         self.eventTime = eventTime
+        self.apiAppId = apiAppId
         self.authedUsers = authedUsers
         self.authorizations = authorizations
         self.eventContext = eventContext
@@ -70,13 +75,16 @@ public struct SlackEventCallback: SlackEventWrapper {
         self.type = try container.decode(String.self, forKey: .type)
         self.token = try container.decode(String.self, forKey: .token)
         self.teamId = try container.decode(String.self, forKey: .teamId)
-        self.apiAppId = try container.decode(String.self, forKey: .apiAppId)
         self.event = try container.decode(AnySlackEvent.self, forKey: .event).event
         self.eventId = try container.decode(String.self, forKey: .eventId)
         self.eventTime = try container.decode(Int.self, forKey: .eventTime)
         self.authedUsers = try container.decodeIfPresent([String].self, forKey: .authedUsers)
         self.authorizations = try container.decodeIfPresent(SlackAuthorizations.self, forKey: .authorizations)
         self.eventContext = try container.decodeIfPresent(String.self, forKey: .eventContext)
+        self.apiAppId = try container.decodeIfPresent(String.self, forKey: .apiAppId)
+        self.isEnterpriseInstall = try container.decodeIfPresent(Bool.self, forKey: .isEnterpriseInstall)
+        self.responseUrls = try container.decodeIfPresent([String].self, forKey: .responseUrls)
+        self.triggerId = try container.decodeIfPresent(String.self, forKey: .triggerId)
     }
     
     public func encode(to encoder: Encoder) throws {
@@ -84,25 +92,31 @@ public struct SlackEventCallback: SlackEventWrapper {
         try container.encode(type, forKey: .type)
         try container.encode(token, forKey: .token)
         try container.encode(teamId, forKey: .teamId)
-        try container.encode(apiAppId, forKey: .apiAppId)
         try container.encode(AnySlackEvent(event), forKey: .event)
         try container.encode(eventId, forKey: .eventId)
         try container.encode(eventTime, forKey: .eventTime)
+        try container.encodeIfPresent(apiAppId, forKey: .apiAppId)
         try container.encodeIfPresent(authedUsers, forKey: .authedUsers)
         try container.encodeIfPresent(authorizations, forKey: .authorizations)
         try container.encodeIfPresent(eventContext, forKey: .eventContext)
+        try container.encodeIfPresent(isEnterpriseInstall, forKey: .isEnterpriseInstall)
+        try container.encodeIfPresent(responseUrls, forKey: .responseUrls)
+        try container.encodeIfPresent(triggerId, forKey: .triggerId)
     }
     
     public enum CodingKeys: String, CodingKey {
         case type
         case token
         case teamId = "team_id"
-        case apiAppId = "api_app_id"
         case event
         case eventId = "event_id"
         case eventTime = "event_time"
         case authedUsers = "authed_users"
         case authorizations
         case eventContext = "event_context"
+        case apiAppId = "api_app_id"
+        case isEnterpriseInstall = "is_enterprise_install"
+        case responseUrls = "response_urls"
+        case triggerId = "trigger_id"
     }
 }

--- a/Sources/SlackBlockKit/Events/SlackEventCallback.swift
+++ b/Sources/SlackBlockKit/Events/SlackEventCallback.swift
@@ -1,0 +1,108 @@
+/// Also referred to as the "outer event", or the JSON object containing the event that happened itself.
+public struct SlackEventCallback: SlackEventWrapper {
+    public static let type: SlackEventWrapperType = .eventCallback
+    /// This reflects the type of callback you're receiving. In this scenario it will be
+    /// `event_callback`. The `event` fields "inner event" will also contain a `type` field
+    /// indicating which event type lurks within.
+    public let type: String
+    /// The shared-private callback token that authenticates this callback to the application as
+    /// having come from Slack. Match this against what you were given when the subscription was
+    /// created. If it does not match, do not process the event and discard it.
+    /// Example: `JhjZd2rVax7ZwH7jRYyWjbDl`
+    public let token: String
+    /// The unique identifier for the workspace/team where this event occurred.
+    /// Example: `T461EG9ZZ`
+    public let teamId: String
+    /// The unique identifier for the application this event is intended for. Your application's
+    /// ID can be found in the URL of the your application console. If your Request URL manages
+    /// multiple applications, use this field along with the `token` field to validate and route
+    /// incoming requests.
+    /// Example: `A4ZFV49KK`
+    public let apiAppId: String
+    /// Contains the inner set of fields representing the event that's happening.
+    public let event: SlackEvent
+    /// A unique identifier for this specific event, globally unique across all workspaces.
+    public let eventId: String
+    /// The epoch timestamp in seconds indicating when this event was dispatched.
+    public let eventTime: Int
+    /// An array of string-based User IDs. Each member of the collection represents a user that
+    /// has installed your application/bot and indicates the described event would be visible to
+    /// those users. You'll receive a single event for a piece of data intended for multiple users
+    /// in a workspace, rather than a message per user.
+    public let authedUsers: [String]?
+    /// An installation of your app. Installations are defined by a combination of the installing
+    /// Enterprise Grid org, workspace, and user (represented by `enterprise_id`, `team_id`, and
+    /// `user_id` inside this field)—note that installations may only have one or two, not all three,
+    /// defined. `authorizations` describes one of the installations that this event is visible to.
+    /// You'll receive a single event for a piece of data intended for multiple users in a workspace,
+    /// rather than a message per user.
+    public let authorizations: SlackAuthorizations?
+    /// An identifier for this specific event. This field can be used with the
+    /// `apps.event.authorizations.list` method to obtain a full list of installations of your app
+    /// that this event is visible to.
+    public let eventContext: String?
+    
+    public init(
+        token: String,
+        teamId: String,
+        apiAppId: String,
+        event: SlackEvent,
+        eventId: String,
+        eventTime: Int,
+        authedUsers: [String]?,
+        authorizations: SlackAuthorizations?,
+        eventContext: String?
+    ) {
+        self.type = Self.type.rawValue
+        self.token = token
+        self.teamId = teamId
+        self.apiAppId = apiAppId
+        self.event = event
+        self.eventId = eventId
+        self.eventTime = eventTime
+        self.authedUsers = authedUsers
+        self.authorizations = authorizations
+        self.eventContext = eventContext
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.type = try container.decode(String.self, forKey: .type)
+        self.token = try container.decode(String.self, forKey: .token)
+        self.teamId = try container.decode(String.self, forKey: .teamId)
+        self.apiAppId = try container.decode(String.self, forKey: .apiAppId)
+        self.event = try container.decode(AnySlackEvent.self, forKey: .event).event
+        self.eventId = try container.decode(String.self, forKey: .eventId)
+        self.eventTime = try container.decode(Int.self, forKey: .eventTime)
+        self.authedUsers = try container.decodeIfPresent([String].self, forKey: .authedUsers)
+        self.authorizations = try container.decodeIfPresent(SlackAuthorizations.self, forKey: .authorizations)
+        self.eventContext = try container.decodeIfPresent(String.self, forKey: .eventContext)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        try container.encode(token, forKey: .token)
+        try container.encode(teamId, forKey: .teamId)
+        try container.encode(apiAppId, forKey: .apiAppId)
+        try container.encode(AnySlackEvent(event), forKey: .event)
+        try container.encode(eventId, forKey: .eventId)
+        try container.encode(eventTime, forKey: .eventTime)
+        try container.encodeIfPresent(authedUsers, forKey: .authedUsers)
+        try container.encodeIfPresent(authorizations, forKey: .authorizations)
+        try container.encodeIfPresent(eventContext, forKey: .eventContext)
+    }
+    
+    public enum CodingKeys: String, CodingKey {
+        case type
+        case token
+        case teamId = "team_id"
+        case apiAppId = "api_app_id"
+        case event
+        case eventId = "event_id"
+        case eventTime = "event_time"
+        case authedUsers = "authed_users"
+        case authorizations
+        case eventContext = "event_context"
+    }
+}

--- a/Sources/SlackBlockKit/Events/SlackEventCallback.swift
+++ b/Sources/SlackBlockKit/Events/SlackEventCallback.swift
@@ -1,5 +1,5 @@
 /// Also referred to as the "outer event", or the JSON object containing the event that happened itself.
-public struct SlackEventCallback: SlackEventWrapper {
+public struct SlackEventCallback: SlackEventWrapper, Equatable {
     public static let type: SlackEventWrapperType = .eventCallback
     /// This reflects the type of callback you're receiving. In this scenario it will be
     /// `event_callback`. The `event` fields "inner event" will also contain a `type` field
@@ -111,6 +111,23 @@ public struct SlackEventCallback: SlackEventWrapper {
         try container.encodeIfPresent(isEnterpriseInstall, forKey: .isEnterpriseInstall)
         try container.encodeIfPresent(responseUrls, forKey: .responseUrls)
         try container.encodeIfPresent(triggerId, forKey: .triggerId)
+    }
+    
+    public static func == (lhs: SlackEventCallback, rhs: SlackEventCallback) -> Bool {
+        return lhs.type == rhs.type &&
+            lhs.token == rhs.token &&
+            lhs.teamId == rhs.teamId &&
+            lhs.event.isEqual(to: rhs.event) &&
+            lhs.eventId == rhs.eventId &&
+            lhs.eventTime == rhs.eventTime &&
+            lhs.apiAppId == rhs.apiAppId &&
+            lhs.authedUsers == rhs.authedUsers &&
+            lhs.authedTeams == rhs.authedTeams &&
+            lhs.authorizations == rhs.authorizations &&
+            lhs.eventContext == rhs.eventContext &&
+            lhs.isEnterpriseInstall == rhs.isEnterpriseInstall &&
+            lhs.responseUrls == rhs.responseUrls &&
+            lhs.triggerId == rhs.triggerId
     }
     
     public enum CodingKeys: String, CodingKey {

--- a/Sources/SlackBlockKit/Events/SlackEventCallback.swift
+++ b/Sources/SlackBlockKit/Events/SlackEventCallback.swift
@@ -24,6 +24,11 @@ public struct SlackEventCallback: SlackEventWrapper {
     /// those users. You'll receive a single event for a piece of data intended for multiple users
     /// in a workspace, rather than a message per user.
     public let authedUsers: [String]?
+    /// An array of string-based team IDs, now truncated to a single workspace. Each member of the
+    /// collection represents a workspace that has installed your application/bot and indicates the
+    /// described event would be visible to that workspace. You'll receive a single event for a piece
+    /// of data intended for multiple workspaces, rather than a message per workspace.
+    public let authedTeams: [String]?
     /// An installation of your app. Installations are defined by a combination of the installing
     /// Enterprise Grid org, workspace, and user (represented by `enterprise_id`, `team_id`, and
     /// `user_id` inside this field)—note that installations may only have one or two, not all three,
@@ -55,6 +60,7 @@ public struct SlackEventCallback: SlackEventWrapper {
         eventTime: Int,
         apiAppId: String? = nil,
         authedUsers: [String]? = nil,
+        authedTeams: [String]? = nil,
         authorizations: SlackAuthorizations? = nil,
         eventContext: String? = nil
     ) {
@@ -66,6 +72,7 @@ public struct SlackEventCallback: SlackEventWrapper {
         self.eventTime = eventTime
         self.apiAppId = apiAppId
         self.authedUsers = authedUsers
+        self.authedTeams = authedTeams
         self.authorizations = authorizations
         self.eventContext = eventContext
     }
@@ -79,6 +86,7 @@ public struct SlackEventCallback: SlackEventWrapper {
         self.eventId = try container.decode(String.self, forKey: .eventId)
         self.eventTime = try container.decode(Int.self, forKey: .eventTime)
         self.authedUsers = try container.decodeIfPresent([String].self, forKey: .authedUsers)
+        self.authedTeams = try container.decodeIfPresent([String].self, forKey: .authedTeams)
         self.authorizations = try container.decodeIfPresent(SlackAuthorizations.self, forKey: .authorizations)
         self.eventContext = try container.decodeIfPresent(String.self, forKey: .eventContext)
         self.apiAppId = try container.decodeIfPresent(String.self, forKey: .apiAppId)
@@ -97,6 +105,7 @@ public struct SlackEventCallback: SlackEventWrapper {
         try container.encode(eventTime, forKey: .eventTime)
         try container.encodeIfPresent(apiAppId, forKey: .apiAppId)
         try container.encodeIfPresent(authedUsers, forKey: .authedUsers)
+        try container.encodeIfPresent(authedTeams, forKey: .authedTeams)
         try container.encodeIfPresent(authorizations, forKey: .authorizations)
         try container.encodeIfPresent(eventContext, forKey: .eventContext)
         try container.encodeIfPresent(isEnterpriseInstall, forKey: .isEnterpriseInstall)
@@ -112,6 +121,7 @@ public struct SlackEventCallback: SlackEventWrapper {
         case eventId = "event_id"
         case eventTime = "event_time"
         case authedUsers = "authed_users"
+        case authedTeams = "authed_teams"
         case authorizations
         case eventContext = "event_context"
         case apiAppId = "api_app_id"

--- a/Sources/SlackBlockKit/Events/URLVerificationEvent.swift
+++ b/Sources/SlackBlockKit/Events/URLVerificationEvent.swift
@@ -5,7 +5,7 @@
 ///
 /// Once you receive the event, verify the request's authenticity and then respond with the
 /// challenge attribute value.
-public struct URLVerificationEvent: SlackEventWrapper {
+public struct URLVerificationEvent: SlackEventWrapper, Equatable {
     public static let type: SlackEventWrapperType = .urlVerification
     /// This payload is similarly formatted to other event types you'll encounter in the Events
     /// API. To help you differentiate url verification requests form other event types, we

--- a/Sources/SlackBlockKit/Events/URLVerificationEvent.swift
+++ b/Sources/SlackBlockKit/Events/URLVerificationEvent.swift
@@ -1,0 +1,31 @@
+/// Verifies ownership of an Events API Request URL.
+///
+/// This event does not require a specific OAuth scope or subscription. You'll automatically
+/// receive it whenever configuring an Events API Request URL.
+///
+/// Once you receive the event, verify the request's authenticity and then respond with the
+/// challenge attribute value.
+public struct URLVerificationEvent: SlackEventWrapper {
+    public static let type: SlackEventWrapperType = .urlVerification
+    /// This payload is similarly formatted to other event types you'll encounter in the Events
+    /// API. To help you differentiate url verification requests form other event types, we
+    /// inform you that this is of the `url_verification` variety.
+    public let type: String
+    /// This deprecated verification token is proof that the request is coming from Slack on
+    /// behalf of your application. You'll find this value in the "App Credentials" section of
+    /// your app's application management interface. Verifying this value is more important
+    /// when working with real events after this verification sequence has been completed.
+    /// When responding to real events, always use the more secure signing secret process to
+    /// verify Slack requests' authenticity.
+    public let token: String
+    /// A randomly generated string produced by Slack. The point of this little game of cat and
+    /// mouse is that you're going to respond to this request with a response body containing
+    /// this value.
+    public let challenge: String
+    
+    public init(token: String, challenge: String) {
+        self.type = Self.type.rawValue
+        self.token = token
+        self.challenge = challenge
+    }
+}

--- a/Sources/SlackBlockKit/Events/URLVerificationEvent.swift
+++ b/Sources/SlackBlockKit/Events/URLVerificationEvent.swift
@@ -23,9 +23,25 @@ public struct URLVerificationEvent: SlackEventWrapper {
     /// this value.
     public let challenge: String
     
+    // The following may also appear
+    public var apiAppId: String?
+    public var isEnterpriseInstall: Bool?
+    public var responseUrls: [String]?
+    public var triggerId: String?
+    
     public init(token: String, challenge: String) {
         self.type = Self.type.rawValue
         self.token = token
         self.challenge = challenge
+    }
+    
+    public enum CodingKeys: String, CodingKey {
+        case type
+        case token
+        case challenge
+        case apiAppId = "api_app_id"
+        case isEnterpriseInstall = "is_enterprise_install"
+        case responseUrls = "response_urls"
+        case triggerId = "trigger_id"
     }
 }

--- a/Sources/SlackBlockKit/Events/UtilTypes/AnySlackEvent.swift
+++ b/Sources/SlackBlockKit/Events/UtilTypes/AnySlackEvent.swift
@@ -1,0 +1,23 @@
+// https://stackoverflow.com/a/44473156/7039100
+struct AnySlackEvent: Codable {
+    let event: SlackEvent
+    
+    init(_ event: SlackEvent) {
+        self.event = event
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(SlackEventType.self, forKey: .type)
+        self.event = try type.eventMetaType.init(from: decoder)
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        try event.encode(to: encoder)
+    }
+    
+    private enum CodingKeys: CodingKey {
+        case type
+        case event
+    }
+}

--- a/Sources/SlackBlockKit/Events/UtilTypes/SlackAuthorizations.swift
+++ b/Sources/SlackBlockKit/Events/UtilTypes/SlackAuthorizations.swift
@@ -4,7 +4,7 @@
 /// defined. `authorizations` describes one of the installations that this event is visible to.
 /// You'll receive a single event for a piece of data intended for multiple users in a workspace,
 /// rather than a message per user.
-public struct SlackAuthorizations: Codable {
+public struct SlackAuthorizations: Codable, Equatable {
     public let enterpriseId: String?
     public let teamId: String?
     public let userId: String?

--- a/Sources/SlackBlockKit/Events/UtilTypes/SlackAuthorizations.swift
+++ b/Sources/SlackBlockKit/Events/UtilTypes/SlackAuthorizations.swift
@@ -1,0 +1,31 @@
+/// An installation of your app. Installations are defined by a combination of the installing
+/// Enterprise Grid org, workspace, and user (represented by `enterprise_id`, `team_id`, and
+/// `user_id` inside this field)—note that installations may only have one or two, not all three,
+/// defined. `authorizations` describes one of the installations that this event is visible to.
+/// You'll receive a single event for a piece of data intended for multiple users in a workspace,
+/// rather than a message per user.
+public struct SlackAuthorizations: Codable {
+    public let enterpriseId: String?
+    public let teamId: String?
+    public let userId: String?
+    public let isBot: Bool?
+    
+    public init(
+        enterpriseId: String?,
+        teamId: String?,
+        userId: String?,
+        isBot: Bool?
+    ) {
+        self.enterpriseId = enterpriseId
+        self.teamId = teamId
+        self.userId = userId
+        self.isBot = isBot
+    }
+    
+    public enum CodingKeys: String, CodingKey {
+        case enterpriseId = "enterprise_id"
+        case teamId = "team_id"
+        case userId = "user_id"
+        case isBot = "is_bot"
+    }
+}

--- a/Sources/SlackBlockKit/Events/UtilTypes/SlackEvent.swift
+++ b/Sources/SlackBlockKit/Events/UtilTypes/SlackEvent.swift
@@ -1,0 +1,5 @@
+/// The Events API is a streamlined, easy way to build apps and bots that respond to activities in Slack.
+public protocol SlackEvent: Codable {
+    static var type: SlackEventType { get }
+    var type: String { get }
+}

--- a/Sources/SlackBlockKit/Events/UtilTypes/SlackEvent.swift
+++ b/Sources/SlackBlockKit/Events/UtilTypes/SlackEvent.swift
@@ -3,3 +3,15 @@ public protocol SlackEvent: Codable {
     static var type: SlackEventType { get }
     var type: String { get }
 }
+
+public extension SlackEvent {
+    func isEqual(to rhs: SlackEvent?) -> Bool {
+        let lhs = self
+        guard let rhs = rhs else { return false }
+        switch Swift.type(of: lhs).type {
+        case .appHomeOpened:
+            guard let lhs = lhs as? AppHomeOpenedEvent, let rhs = rhs as? AppHomeOpenedEvent else { return false }
+            return lhs == rhs
+        }
+    }
+}

--- a/Sources/SlackBlockKit/Events/UtilTypes/SlackEventType.swift
+++ b/Sources/SlackBlockKit/Events/UtilTypes/SlackEventType.swift
@@ -1,0 +1,9 @@
+public enum SlackEventType: String, Codable {
+    case appHomeOpened = "app_home_opened"
+    
+    var eventMetaType: SlackEvent.Type {
+        switch self {
+        case .appHomeOpened: return AppHomeOpenedEvent.self
+        }
+    }
+}

--- a/Sources/SlackBlockKit/Events/UtilTypes/SlackEventWrapper.swift
+++ b/Sources/SlackBlockKit/Events/UtilTypes/SlackEventWrapper.swift
@@ -3,4 +3,9 @@
 public protocol SlackEventWrapper: Codable {
     static var type: SlackEventWrapperType { get }
     var type: String { get }
+    var token: String { get }
+    var apiAppId: String? { get set }
+    var isEnterpriseInstall: Bool? { get set }
+    var responseUrls: [String]?  { get set }
+    var triggerId: String? { get set }
 }

--- a/Sources/SlackBlockKit/Events/UtilTypes/SlackEventWrapper.swift
+++ b/Sources/SlackBlockKit/Events/UtilTypes/SlackEventWrapper.swift
@@ -1,0 +1,6 @@
+/// The Events API is a streamlined, easy way to build apps and bots that respond to activities in Slack.
+/// Your Request URL will receive JSON-based payloads containing wrapped event types.
+public protocol SlackEventWrapper: Codable {
+    static var type: SlackEventWrapperType { get }
+    var type: String { get }
+}

--- a/Sources/SlackBlockKit/Events/UtilTypes/SlackEventWrapperType.swift
+++ b/Sources/SlackBlockKit/Events/UtilTypes/SlackEventWrapperType.swift
@@ -1,4 +1,6 @@
 public enum SlackEventWrapperType: String, Codable {
     case urlVerification = "url_verification"
     case eventCallback = "event_callback"
+    case viewSubmission = "view_submission"
+    case viewClosed = "view_closed"
 }

--- a/Sources/SlackBlockKit/Events/UtilTypes/SlackEventWrapperType.swift
+++ b/Sources/SlackBlockKit/Events/UtilTypes/SlackEventWrapperType.swift
@@ -1,0 +1,4 @@
+public enum SlackEventWrapperType: String, Codable {
+    case urlVerification = "url_verification"
+    case eventCallback = "event_callback"
+}

--- a/Sources/SlackBlockKit/Events/UtilTypes/SlackTeam.swift
+++ b/Sources/SlackBlockKit/Events/UtilTypes/SlackTeam.swift
@@ -1,0 +1,10 @@
+/// The workspace that the interaction happened in.
+public struct SlackTeam: Codable, Equatable {
+    public let id: String
+    public let domain: String
+    
+    public init(id: String, domain: String) {
+        self.id = id
+        self.domain = domain
+    }
+}

--- a/Sources/SlackBlockKit/Events/UtilTypes/SlackUser.swift
+++ b/Sources/SlackBlockKit/Events/UtilTypes/SlackUser.swift
@@ -1,0 +1,26 @@
+/// The user who interacted to trigger this request.
+public struct SlackUser: Codable, Equatable {
+    public let id: String
+    public let username: String?
+    public let name: String?
+    public let teamId: String?
+    
+    public init(
+        id: String,
+        username: String? = nil,
+        name: String? = nil,
+        teamId: String? = nil
+    ) {
+        self.id = id
+        self.username = username
+        self.name = name
+        self.teamId = teamId
+    }
+    
+    public enum CodingKeys: String, CodingKey {
+        case id
+        case username
+        case name
+        case teamId = "team_id"
+    }
+}

--- a/Sources/SlackBlockKit/Events/ViewClosedEvent.swift
+++ b/Sources/SlackBlockKit/Events/ViewClosedEvent.swift
@@ -1,3 +1,6 @@
+// TODO - ViewClosed and ViewSubmission are actually actions (not events). In a separate PR I will
+// separate them out from the other events.
+
 /// Optionally received when a user dismisses a modal.
 public struct ViewClosedEvent: SlackEventWrapper, Equatable {
     public static let type: SlackEventWrapperType = .viewClosed

--- a/Sources/SlackBlockKit/Events/ViewClosedEvent.swift
+++ b/Sources/SlackBlockKit/Events/ViewClosedEvent.swift
@@ -1,3 +1,4 @@
+/// Optionally received when a user dismisses a modal.
 public struct ViewClosedEvent: SlackEventWrapper, Equatable {
     public static let type: SlackEventWrapperType = .viewClosed
     /// Helps identify the source of the payload. The `type` for this interaction is `view_closed`.

--- a/Sources/SlackBlockKit/Events/ViewClosedEvent.swift
+++ b/Sources/SlackBlockKit/Events/ViewClosedEvent.swift
@@ -1,0 +1,51 @@
+public struct ViewClosedEvent: SlackEventWrapper, Equatable {
+    public static let type: SlackEventWrapperType = .viewClosed
+    /// Helps identify the source of the payload. The `type` for this interaction is `view_closed`.
+    public let type: String
+    /// The shared-private callback token that authenticates this callback to the application as
+    /// having come from Slack. Match this against what you were given when the subscription was
+    /// created. If it does not match, do not process the event and discard it.
+    public let token: String
+    /// The workspace that the interaction happened in.
+    public let team: SlackTeam
+    /// The user who interacted to trigger this request.
+    public let user: SlackUser
+    /// The source view of the modal that the user submitted.
+    public let view: ModalView
+    /// A boolean that represents whether or not a whole view stack was cleared.
+    public let isCleared: Bool?
+    
+    // The following may also appear
+    public var apiAppId: String?
+    public var isEnterpriseInstall: Bool?
+    public var responseUrls: [String]?
+    public var triggerId: String?
+    
+    public init(
+        token: String,
+        team: SlackTeam,
+        user: SlackUser,
+        view: ModalView,
+        isCleared: Bool? = nil
+    ) {
+        self.type = Self.type.rawValue
+        self.token = token
+        self.team = team
+        self.user = user
+        self.view = view
+        self.isCleared = isCleared
+    }
+    
+    public enum CodingKeys: String, CodingKey {
+        case type
+        case token
+        case team
+        case user
+        case view
+        case isCleared = "is_cleared"
+        case apiAppId = "api_app_id"
+        case isEnterpriseInstall = "is_enterprise_install"
+        case responseUrls = "response_urls"
+        case triggerId = "trigger_id"
+    }
+}

--- a/Sources/SlackBlockKit/Events/ViewSubmissionEvent.swift
+++ b/Sources/SlackBlockKit/Events/ViewSubmissionEvent.swift
@@ -1,0 +1,47 @@
+/// Received when a user submits a view in a modal.
+public struct ViewSubmissionEvent: SlackEventWrapper, Equatable {
+    public static let type: SlackEventWrapperType = .viewSubmission
+    /// Helps identify the source of the payload. The `type` for this interaction is `view_submission`.
+    public let type: String
+    /// The shared-private callback token that authenticates this callback to the application as
+    /// having come from Slack. Match this against what you were given when the subscription was
+    /// created. If it does not match, do not process the event and discard it.
+    public let token: String
+    /// The workspace that the interaction happened in.
+    public let team: SlackTeam
+    /// The user who interacted to trigger this request.
+    public let user: SlackUser
+    /// The source view of the modal that the user submitted.
+    public let view: ModalView
+    
+    // The following may also appear
+    public var apiAppId: String?
+    public var isEnterpriseInstall: Bool?
+    public var responseUrls: [String]?
+    public var triggerId: String?
+    
+    public init(
+        token: String,
+        team: SlackTeam,
+        user: SlackUser,
+        view: ModalView
+    ) {
+        self.type = Self.type.rawValue
+        self.token = token
+        self.team = team
+        self.user = user
+        self.view = view
+    }
+    
+    public enum CodingKeys: String, CodingKey {
+        case type
+        case token
+        case team
+        case user
+        case view
+        case apiAppId = "api_app_id"
+        case isEnterpriseInstall = "is_enterprise_install"
+        case responseUrls = "response_urls"
+        case triggerId = "trigger_id"
+    }
+}

--- a/Sources/SlackBlockKit/Events/ViewSubmissionEvent.swift
+++ b/Sources/SlackBlockKit/Events/ViewSubmissionEvent.swift
@@ -1,3 +1,6 @@
+// TODO - ViewSubmission and ViewClosed are actually actions (not events). In a separate PR I will
+// separate them out from the other events.
+
 /// Received when a user submits a view in a modal.
 public struct ViewSubmissionEvent: SlackEventWrapper, Equatable {
     public static let type: SlackEventWrapperType = .viewSubmission

--- a/Sources/SlackBlockKit/LayoutBlocks/ActionsBlock.swift
+++ b/Sources/SlackBlockKit/LayoutBlocks/ActionsBlock.swift
@@ -58,7 +58,7 @@ public struct ActionsBlock: LayoutBlock, Equatable {
     public static func == (lhs: ActionsBlock, rhs: ActionsBlock) -> Bool {
         guard lhs.elements.count == rhs.elements.count else { return false }
         for (index, element) in lhs.elements.enumerated() {
-            guard isEqual(lhs: element, rhs: rhs.elements[index]) else { return false }
+            guard element.isEqual(to: rhs.elements[index]) else { return false }
         }
         return lhs.type == rhs.type && lhs.blockId == rhs.blockId
     }

--- a/Sources/SlackBlockKit/LayoutBlocks/ContextBlock.swift
+++ b/Sources/SlackBlockKit/LayoutBlocks/ContextBlock.swift
@@ -56,7 +56,7 @@ public struct ContextBlock: LayoutBlock, Equatable {
     public static func == (lhs: ContextBlock, rhs: ContextBlock) -> Bool {
         guard lhs.elements.count == rhs.elements.count else { return false }
         for (index, element) in lhs.elements.enumerated() {
-            guard isEqual(lhs: element, rhs: rhs.elements[index]) else { return false }
+            guard element.isEqual(to: rhs.elements[index]) else { return false }
         }
         return lhs.type == rhs.type && lhs.blockId == rhs.blockId
     }

--- a/Sources/SlackBlockKit/LayoutBlocks/InputBlock.swift
+++ b/Sources/SlackBlockKit/LayoutBlocks/InputBlock.swift
@@ -85,7 +85,7 @@ public struct InputBlock: LayoutBlock, Equatable {
         return
             lhs.type == rhs.type &&
             lhs.label == rhs.label &&
-            isEqual(lhs: lhs.element, rhs: rhs.element) &&
+            lhs.element.isEqual(to: rhs.element) &&
             lhs.dispatchAction == rhs.dispatchAction &&
             lhs.blockId == rhs.blockId &&
             lhs.hint == rhs.hint &&

--- a/Sources/SlackBlockKit/LayoutBlocks/SectionBlock.swift
+++ b/Sources/SlackBlockKit/LayoutBlocks/SectionBlock.swift
@@ -91,7 +91,7 @@ public struct SectionBlock: LayoutBlock, Equatable {
             lhs.text == rhs.text &&
             lhs.blockId == rhs.blockId &&
             lhs.fields == rhs.fields &&
-            isEqual(lhs: lhs.accessory, rhs: rhs.accessory)
+            lhs.accessory?.isEqual(to: rhs.accessory) ?? (rhs.accessory == nil)
     }
     
     public enum CodingKeys: String, CodingKey {

--- a/Sources/SlackBlockKit/LayoutBlocks/UtilTypes/LayoutBlock.swift
+++ b/Sources/SlackBlockKit/LayoutBlocks/UtilTypes/LayoutBlock.swift
@@ -5,33 +5,36 @@ public protocol LayoutBlock: Codable {
     var type: String { get }
 }
 
-public func isEqual(lhs: LayoutBlock?, rhs: LayoutBlock?) -> Bool {
-    guard let lhs = lhs, let rhs = rhs else { return false }
-    
-    switch Swift.type(of: lhs).type {
-    case .actions:
-        guard let lhs = lhs as? ActionsBlock, let rhs = rhs as? ActionsBlock else { return false }
-        return lhs == rhs
-    case .context:
-        guard let lhs = lhs as? ContextBlock, let rhs = rhs as? ContextBlock else { return false }
-        return lhs == rhs
-    case .divider:
-        guard let lhs = lhs as? DividerBlock, let rhs = rhs as? DividerBlock else { return false }
-        return lhs == rhs
-    case .file:
-        guard let lhs = lhs as? FileBlock, let rhs = rhs as? FileBlock else { return false }
-        return lhs == rhs
-    case .header:
-        guard let lhs = lhs as? HeaderBlock, let rhs = rhs as? HeaderBlock else { return false }
-        return lhs == rhs
-    case .image:
-        guard let lhs = lhs as? ImageBlock, let rhs = rhs as? ImageBlock else { return false }
-        return lhs == rhs
-    case .input:
-        guard let lhs = lhs as? InputBlock, let rhs = rhs as? InputBlock else { return false }
-        return lhs == rhs
-    case .section:
-        guard let lhs = lhs as? SectionBlock, let rhs = rhs as? SectionBlock else { return false }
-        return lhs == rhs
+public extension LayoutBlock {
+    func isEqual(to rhs: LayoutBlock?) -> Bool {
+        let lhs = self
+        guard let rhs = rhs else { return false }
+        
+        switch Swift.type(of: lhs).type {
+        case .actions:
+            guard let lhs = lhs as? ActionsBlock, let rhs = rhs as? ActionsBlock else { return false }
+            return lhs == rhs
+        case .context:
+            guard let lhs = lhs as? ContextBlock, let rhs = rhs as? ContextBlock else { return false }
+            return lhs == rhs
+        case .divider:
+            guard let lhs = lhs as? DividerBlock, let rhs = rhs as? DividerBlock else { return false }
+            return lhs == rhs
+        case .file:
+            guard let lhs = lhs as? FileBlock, let rhs = rhs as? FileBlock else { return false }
+            return lhs == rhs
+        case .header:
+            guard let lhs = lhs as? HeaderBlock, let rhs = rhs as? HeaderBlock else { return false }
+            return lhs == rhs
+        case .image:
+            guard let lhs = lhs as? ImageBlock, let rhs = rhs as? ImageBlock else { return false }
+            return lhs == rhs
+        case .input:
+            guard let lhs = lhs as? InputBlock, let rhs = rhs as? InputBlock else { return false }
+            return lhs == rhs
+        case .section:
+            guard let lhs = lhs as? SectionBlock, let rhs = rhs as? SectionBlock else { return false }
+            return lhs == rhs
+        }
     }
 }

--- a/Sources/SlackBlockKit/LayoutBlocks/UtilTypes/LayoutBlock.swift
+++ b/Sources/SlackBlockKit/LayoutBlocks/UtilTypes/LayoutBlock.swift
@@ -6,18 +6,6 @@ public protocol LayoutBlock: Codable {
 }
 
 public func isEqual(lhs: LayoutBlock?, rhs: LayoutBlock?) -> Bool {
-    switch lhs {
-    case .none:
-        switch rhs {
-        case .none: return true
-        case .some: return false
-        }
-    case .some:
-        switch rhs {
-        case .none: return false
-        case .some: break
-        }
-    }
     guard let lhs = lhs, let rhs = rhs else { return false }
     
     switch Swift.type(of: lhs).type {

--- a/Sources/SlackBlockKit/MessagePayloads/MessagePayload.swift
+++ b/Sources/SlackBlockKit/MessagePayloads/MessagePayload.swift
@@ -96,7 +96,7 @@ public struct MessagePayload: Codable, Equatable {
     public static func == (lhs: MessagePayload, rhs: MessagePayload) -> Bool {
         guard lhs.blocks?.count == rhs.blocks?.count else { return false }
         if let lhsBlocks = lhs.blocks {
-            guard lhsBlocks.enumerated().allSatisfy({ isEqual(lhs: $1, rhs: rhs.blocks?[$0]) }) else { return false }
+            guard lhsBlocks.enumerated().allSatisfy({ $1.isEqual(to: rhs.blocks?[$0]) }) else { return false }
         }
         return
             lhs.text == rhs.text &&

--- a/Sources/SlackBlockKit/MessagePayloads/SecondaryMessageAttachement.swift
+++ b/Sources/SlackBlockKit/MessagePayloads/SecondaryMessageAttachement.swift
@@ -272,7 +272,7 @@ public struct SecondaryMessageAttachment: Codable, Equatable {
     public static func == (lhs: SecondaryMessageAttachment, rhs: SecondaryMessageAttachment) -> Bool {
         guard lhs.blocks?.count == rhs.blocks?.count else { return false }
         if let lhsBlocks = lhs.blocks {
-            guard lhsBlocks.enumerated().allSatisfy({ isEqual(lhs: $1, rhs: rhs.blocks?[$0]) }) else { return false }
+            guard lhsBlocks.enumerated().allSatisfy({ $1.isEqual(to: rhs.blocks?[$0]) }) else { return false }
         }
         return
             lhs.color == rhs.color &&

--- a/Sources/SlackBlockKit/StateValues/CheckboxGroupsStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/CheckboxGroupsStateValue.swift
@@ -1,0 +1,15 @@
+public struct CheckboxGroupsStateValue: StateValue {
+    public static let type: StateValueType = .checkboxes
+    public let type: String
+    public let selectedOptions: [StateValueSelectedOption]
+    
+    public init(selectedOptions: [StateValueSelectedOption]) {
+        self.type = Self.type.rawValue
+        self.selectedOptions = selectedOptions
+    }
+    
+    public enum CodingKeys: String, CodingKey {
+        case type
+        case selectedOptions = "selected_options"
+    }
+}

--- a/Sources/SlackBlockKit/StateValues/CheckboxGroupsStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/CheckboxGroupsStateValue.swift
@@ -1,4 +1,4 @@
-public struct CheckboxGroupsStateValue: StateValue {
+public struct CheckboxGroupsStateValue: StateValue, Equatable {
     public static let type: StateValueType = .checkboxes
     public let type: String
     public let selectedOptions: [StateValueSelectedOption]

--- a/Sources/SlackBlockKit/StateValues/DatePickerStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/DatePickerStateValue.swift
@@ -1,0 +1,15 @@
+public struct DatePickerStateValue: StateValue {
+    public static let type: StateValueType = .datepicker
+    public let type: String
+    public let selectedDate: String
+    
+    public init(selectedDate: String) {
+        self.type = Self.type.rawValue
+        self.selectedDate = selectedDate
+    }
+    
+    public enum CodingKeys: String, CodingKey {
+        case type
+        case selectedDate = "selected_date"
+    }
+}

--- a/Sources/SlackBlockKit/StateValues/DatePickerStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/DatePickerStateValue.swift
@@ -1,4 +1,4 @@
-public struct DatePickerStateValue: StateValue {
+public struct DatePickerStateValue: StateValue, Equatable {
     public static let type: StateValueType = .datepicker
     public let type: String
     public let selectedDate: String

--- a/Sources/SlackBlockKit/StateValues/MultiSelectMenuConversationsListStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/MultiSelectMenuConversationsListStateValue.swift
@@ -1,0 +1,15 @@
+public struct MultiSelectMenuConversationsListStateValue: StateValue {
+    public static let type: StateValueType = .multiConversationsSelect
+    public let type: String
+    public let selectedConversations: [String]
+    
+    public init(selectedConversations: [String]) {
+        self.type = Self.type.rawValue
+        self.selectedConversations = selectedConversations
+    }
+    
+    public enum CodingKeys: String, CodingKey {
+        case type
+        case selectedConversations = "selected_conversations"
+    }
+}

--- a/Sources/SlackBlockKit/StateValues/MultiSelectMenuConversationsListStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/MultiSelectMenuConversationsListStateValue.swift
@@ -1,4 +1,4 @@
-public struct MultiSelectMenuConversationsListStateValue: StateValue {
+public struct MultiSelectMenuConversationsListStateValue: StateValue, Equatable {
     public static let type: StateValueType = .multiConversationsSelect
     public let type: String
     public let selectedConversations: [String]

--- a/Sources/SlackBlockKit/StateValues/MultiSelectMenuPublicChannelsListStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/MultiSelectMenuPublicChannelsListStateValue.swift
@@ -1,0 +1,15 @@
+public struct MultiSelectMenuPublicChannelsListStateValue: StateValue {
+    public static let type: StateValueType = .multiChannelsSelect
+    public let type: String
+    public let selectedChannels: [String]
+    
+    public init(selectedChannels: [String]) {
+        self.type = Self.type.rawValue
+        self.selectedChannels = selectedChannels
+    }
+    
+    public enum CodingKeys: String, CodingKey {
+        case type
+        case selectedChannels = "selected_channels"
+    }
+}

--- a/Sources/SlackBlockKit/StateValues/MultiSelectMenuPublicChannelsListStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/MultiSelectMenuPublicChannelsListStateValue.swift
@@ -1,4 +1,4 @@
-public struct MultiSelectMenuPublicChannelsListStateValue: StateValue {
+public struct MultiSelectMenuPublicChannelsListStateValue: StateValue, Equatable {
     public static let type: StateValueType = .multiChannelsSelect
     public let type: String
     public let selectedChannels: [String]

--- a/Sources/SlackBlockKit/StateValues/MultiSelectMenuStaticOptionsStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/MultiSelectMenuStaticOptionsStateValue.swift
@@ -1,4 +1,4 @@
-public struct MultiSelectMenuStaticOptionsStateValue: StateValue {
+public struct MultiSelectMenuStaticOptionsStateValue: StateValue, Equatable {
     public static let type: StateValueType = .multiStaticSelect
     public let type: String
     public let selectedOptions: [StateValueSelectedOption]

--- a/Sources/SlackBlockKit/StateValues/MultiSelectMenuStaticOptionsStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/MultiSelectMenuStaticOptionsStateValue.swift
@@ -1,0 +1,15 @@
+public struct MultiSelectMenuStaticOptionsStateValue: StateValue {
+    public static let type: StateValueType = .multiStaticSelect
+    public let type: String
+    public let selectedOptions: [StateValueSelectedOption]
+    
+    public init(selectedOptions: [StateValueSelectedOption]) {
+        self.type = Self.type.rawValue
+        self.selectedOptions = selectedOptions
+    }
+    
+    public enum CodingKeys: String, CodingKey {
+        case type
+        case selectedOptions = "selected_options"
+    }
+}

--- a/Sources/SlackBlockKit/StateValues/MultiSelectMenuUserListStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/MultiSelectMenuUserListStateValue.swift
@@ -1,0 +1,15 @@
+public struct MultiSelectMenuUserListStateValue: StateValue {
+    public static let type: StateValueType = .multiUsersSelect
+    public let type: String
+    public let selectedUsers: [String]
+    
+    public init(selectedUsers: [String]) {
+        self.type = Self.type.rawValue
+        self.selectedUsers = selectedUsers
+    }
+    
+    public enum CodingKeys: String, CodingKey {
+        case type
+        case selectedUsers = "selected_users"
+    }
+}

--- a/Sources/SlackBlockKit/StateValues/MultiSelectMenuUserListStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/MultiSelectMenuUserListStateValue.swift
@@ -1,4 +1,4 @@
-public struct MultiSelectMenuUserListStateValue: StateValue {
+public struct MultiSelectMenuUserListStateValue: StateValue, Equatable {
     public static let type: StateValueType = .multiUsersSelect
     public let type: String
     public let selectedUsers: [String]

--- a/Sources/SlackBlockKit/StateValues/PlainTextInputStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/PlainTextInputStateValue.swift
@@ -1,4 +1,4 @@
-public struct PlainTextInputStateValue: StateValue {
+public struct PlainTextInputStateValue: StateValue, Equatable {
     public static let type: StateValueType = .plainTextInput
     public let type: String
     public let value: String?

--- a/Sources/SlackBlockKit/StateValues/PlainTextInputStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/PlainTextInputStateValue.swift
@@ -1,0 +1,27 @@
+public struct PlainTextInputStateValue: StateValue {
+    public static let type: StateValueType = .plainTextInput
+    public let type: String
+    public let value: String?
+    
+    public init(value: String?) {
+        self.type = Self.type.rawValue
+        self.value = value
+    }
+    
+    // The value is always needed, so we override the synthesized encode method, to ensure
+    // that even if value is nil, that it will still be encoded into the final output.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        if let value = value {
+            try container.encode(value, forKey: .value)
+        } else {
+            try container.encodeNil(forKey: .value)
+        }
+    }
+    
+    public enum CodingKeys: String, CodingKey {
+        case type
+        case value
+    }
+}

--- a/Sources/SlackBlockKit/StateValues/RadioButtonGroupStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/RadioButtonGroupStateValue.swift
@@ -1,4 +1,4 @@
-public struct RadioButtonGroupStateValue: StateValue {
+public struct RadioButtonGroupStateValue: StateValue, Equatable {
     public static let type: StateValueType = .radioButtons
     public let type: String
     public let selectedOption: StateValueSelectedOption?

--- a/Sources/SlackBlockKit/StateValues/RadioButtonGroupStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/RadioButtonGroupStateValue.swift
@@ -1,0 +1,27 @@
+public struct RadioButtonGroupStateValue: StateValue {
+    public static let type: StateValueType = .radioButtons
+    public let type: String
+    public let selectedOption: StateValueSelectedOption?
+    
+    public init(selectedOption: StateValueSelectedOption?) {
+        self.type = Self.type.rawValue
+        self.selectedOption = selectedOption
+    }
+    
+    // The selectedOption is always needed, so we override the synthesized encode method, to ensure
+    // that even if selectedOption is nil, that it will still be encoded into the final output.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        if let selectedOption = selectedOption {
+            try container.encode(selectedOption, forKey: .selectedOption)
+        } else {
+            try container.encodeNil(forKey: .selectedOption)
+        }
+    }
+    
+    public enum CodingKeys: String, CodingKey {
+        case type
+        case selectedOption = "selected_option"
+    }
+}

--- a/Sources/SlackBlockKit/StateValues/SelectMenuConversationsListStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/SelectMenuConversationsListStateValue.swift
@@ -1,0 +1,31 @@
+public struct SelectMenuConversationsListStateValue: StateValue {
+    public static let type: StateValueType = .conversationsSelect
+    public let type: String
+    public let selectedConversation: String?
+    public let responseUrlEnabled: Bool?
+    
+    public init(selectedConversation: String?, responseUrlEnabled: Bool?) {
+        self.type = Self.type.rawValue
+        self.selectedConversation = selectedConversation
+        self.responseUrlEnabled = responseUrlEnabled
+    }
+    
+    // The selectedConversation is always needed, so we override the synthesized encode method, to ensure
+    // that even if selectedConversation is nil, that it will still be encoded into the final output.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        if let selectedConversation = selectedConversation {
+            try container.encode(selectedConversation, forKey: .selectedConversation)
+        } else {
+            try container.encodeNil(forKey: .selectedConversation)
+        }
+        try container.encodeIfPresent(responseUrlEnabled, forKey: .responseUrlEnabled)
+    }
+    
+    public enum CodingKeys: String, CodingKey {
+        case type
+        case selectedConversation = "selected_conversation"
+        case responseUrlEnabled = "response_url_enabled"
+    }
+}

--- a/Sources/SlackBlockKit/StateValues/SelectMenuConversationsListStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/SelectMenuConversationsListStateValue.swift
@@ -4,7 +4,7 @@ public struct SelectMenuConversationsListStateValue: StateValue, Equatable {
     public let selectedConversation: String?
     public let responseUrlEnabled: Bool?
     
-    public init(selectedConversation: String?, responseUrlEnabled: Bool?) {
+    public init(selectedConversation: String?, responseUrlEnabled: Bool? = nil) {
         self.type = Self.type.rawValue
         self.selectedConversation = selectedConversation
         self.responseUrlEnabled = responseUrlEnabled

--- a/Sources/SlackBlockKit/StateValues/SelectMenuConversationsListStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/SelectMenuConversationsListStateValue.swift
@@ -1,4 +1,4 @@
-public struct SelectMenuConversationsListStateValue: StateValue {
+public struct SelectMenuConversationsListStateValue: StateValue, Equatable {
     public static let type: StateValueType = .conversationsSelect
     public let type: String
     public let selectedConversation: String?

--- a/Sources/SlackBlockKit/StateValues/SelectMenuPublicChannelsListStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/SelectMenuPublicChannelsListStateValue.swift
@@ -1,4 +1,4 @@
-public struct SelectMenuPublicChannelsListStateValue: StateValue {
+public struct SelectMenuPublicChannelsListStateValue: StateValue, Equatable {
     public static let type: StateValueType = .channelsSelect
     public let type: String
     public let selectedChannel: String?

--- a/Sources/SlackBlockKit/StateValues/SelectMenuPublicChannelsListStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/SelectMenuPublicChannelsListStateValue.swift
@@ -1,0 +1,31 @@
+public struct SelectMenuPublicChannelsListStateValue: StateValue {
+    public static let type: StateValueType = .channelsSelect
+    public let type: String
+    public let selectedChannel: String?
+    public let responseUrlEnabled: Bool?
+    
+    public init(selectedChannel: String?, responseUrlEnabled: Bool?) {
+        self.type = Self.type.rawValue
+        self.selectedChannel = selectedChannel
+        self.responseUrlEnabled = responseUrlEnabled
+    }
+    
+    // The selectedChannel is always needed, so we override the synthesized encode method, to ensure
+    // that even if selectedChannel is nil, that it will still be encoded into the final output.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        if let selectedChannel = selectedChannel {
+            try container.encode(selectedChannel, forKey: .selectedChannel)
+        } else {
+            try container.encodeNil(forKey: .selectedChannel)
+        }
+        try container.encodeIfPresent(responseUrlEnabled, forKey: .responseUrlEnabled)
+    }
+    
+    public enum CodingKeys: String, CodingKey {
+        case type
+        case selectedChannel = "selected_channel"
+        case responseUrlEnabled = "response_url_enabled"
+    }
+}

--- a/Sources/SlackBlockKit/StateValues/SelectMenuPublicChannelsListStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/SelectMenuPublicChannelsListStateValue.swift
@@ -4,7 +4,7 @@ public struct SelectMenuPublicChannelsListStateValue: StateValue, Equatable {
     public let selectedChannel: String?
     public let responseUrlEnabled: Bool?
     
-    public init(selectedChannel: String?, responseUrlEnabled: Bool?) {
+    public init(selectedChannel: String?, responseUrlEnabled: Bool? = nil) {
         self.type = Self.type.rawValue
         self.selectedChannel = selectedChannel
         self.responseUrlEnabled = responseUrlEnabled

--- a/Sources/SlackBlockKit/StateValues/SelectMenuStaticOptionsStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/SelectMenuStaticOptionsStateValue.swift
@@ -1,4 +1,4 @@
-public struct SelectMenuStaticOptionsStateValue: StateValue {
+public struct SelectMenuStaticOptionsStateValue: StateValue, Equatable {
     public static let type: StateValueType = .staticSelect
     public let type: String
     public let selectedOption: StateValueSelectedOption?

--- a/Sources/SlackBlockKit/StateValues/SelectMenuStaticOptionsStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/SelectMenuStaticOptionsStateValue.swift
@@ -1,0 +1,27 @@
+public struct SelectMenuStaticOptionsStateValue: StateValue {
+    public static let type: StateValueType = .staticSelect
+    public let type: String
+    public let selectedOption: StateValueSelectedOption?
+    
+    public init(selectedOption: StateValueSelectedOption?) {
+        self.type = Self.type.rawValue
+        self.selectedOption = selectedOption
+    }
+    
+    // The selectedOption is always needed, so we override the synthesized encode method, to ensure
+    // that even if selectedOption is nil, that it will still be encoded into the final output.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        if let selectedOption = selectedOption {
+            try container.encode(selectedOption, forKey: .selectedOption)
+        } else {
+            try container.encodeNil(forKey: .selectedOption)
+        }
+    }
+    
+    public enum CodingKeys: String, CodingKey {
+        case type
+        case selectedOption = "selected_option"
+    }
+}

--- a/Sources/SlackBlockKit/StateValues/SelectMenuUserListStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/SelectMenuUserListStateValue.swift
@@ -1,4 +1,4 @@
-public struct SelectMenuUserListStateValue: StateValue {
+public struct SelectMenuUserListStateValue: StateValue, Equatable {
     public static let type: StateValueType = .usersSelect
     public let type: String
     public let selectedUser: String?

--- a/Sources/SlackBlockKit/StateValues/SelectMenuUserListStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/SelectMenuUserListStateValue.swift
@@ -1,0 +1,27 @@
+public struct SelectMenuUserListStateValue: StateValue {
+    public static let type: StateValueType = .usersSelect
+    public let type: String
+    public let selectedUser: String?
+    
+    public init(selectedUser: String?) {
+        self.type = Self.type.rawValue
+        self.selectedUser = selectedUser
+    }
+    
+    // The selectedUser is always needed, so we override the synthesized encode method, to ensure
+    // that even if selectedUser is nil, that it will still be encoded into the final output.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        if let selectedUser = selectedUser {
+            try container.encode(selectedUser, forKey: .selectedUser)
+        } else {
+            try container.encodeNil(forKey: .selectedUser)
+        }
+    }
+    
+    public enum CodingKeys: String, CodingKey {
+        case type
+        case selectedUser = "selected_user"
+    }
+}

--- a/Sources/SlackBlockKit/StateValues/TimePickerStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/TimePickerStateValue.swift
@@ -1,4 +1,4 @@
-public struct TimePickerStateValue: StateValue {
+public struct TimePickerStateValue: StateValue, Equatable {
     public static let type: StateValueType = .timepicker
     public let type: String
     public let selectedTime: String

--- a/Sources/SlackBlockKit/StateValues/TimePickerStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/TimePickerStateValue.swift
@@ -1,0 +1,15 @@
+public struct TimePickerStateValue: StateValue {
+    public static let type: StateValueType = .timepicker
+    public let type: String
+    public let selectedTime: String
+    
+    public init(selectedTime: String) {
+        self.type = Self.type.rawValue
+        self.selectedTime = selectedTime
+    }
+    
+    public enum CodingKeys: String, CodingKey {
+        case type
+        case selectedTime = "selected_time"
+    }
+}

--- a/Sources/SlackBlockKit/StateValues/UtilTypes/AnyStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/UtilTypes/AnyStateValue.swift
@@ -1,0 +1,23 @@
+// https://stackoverflow.com/a/44473156/7039100
+struct AnyStateValue: Codable {
+    let value: StateValue
+    
+    init(_ value: StateValue) {
+        self.value = value
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(StateValueType.self, forKey: .type)
+        self.value = try type.eventMetaType.init(from: decoder)
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        try value.encode(to: encoder)
+    }
+    
+    private enum CodingKeys: CodingKey {
+        case type
+        case value
+    }
+}

--- a/Sources/SlackBlockKit/StateValues/UtilTypes/AnyStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/UtilTypes/AnyStateValue.swift
@@ -21,3 +21,5 @@ struct AnyStateValue: Codable {
         case value
     }
 }
+
+typealias AnyStateValues = [String: [String: AnyStateValue]]

--- a/Sources/SlackBlockKit/StateValues/UtilTypes/StateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/UtilTypes/StateValue.swift
@@ -1,0 +1,7 @@
+/// This final child object will contain the type and value of the action block element.
+/// If the call originates from a Home tab or modal view it will be in `view.state.values`
+/// and if it originates from a message it will be in `state.values`.
+public protocol StateValue: Codable {
+    static var type: StateValueType { get }
+    var type: String { get }
+}

--- a/Sources/SlackBlockKit/StateValues/UtilTypes/StateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/UtilTypes/StateValue.swift
@@ -5,3 +5,70 @@ public protocol StateValue: Codable {
     static var type: StateValueType { get }
     var type: String { get }
 }
+
+public typealias StateValues = [String: [String: StateValue]]
+
+public extension StateValue {
+    func isEqual(to rhs: StateValue?) -> Bool {
+        let lhs = self
+        guard let rhs = rhs else { return false }
+        
+        switch Swift.type(of: lhs).type {
+        case .checkboxes:
+            guard let lhs = lhs as? CheckboxGroupsStateValue, let rhs = rhs as? CheckboxGroupsStateValue else { return false }
+            return lhs == rhs
+        case .datepicker:
+            guard let lhs = lhs as? DatePickerStateValue, let rhs = rhs as? DatePickerStateValue else { return false }
+            return lhs == rhs
+        case .plainTextInput:
+            guard let lhs = lhs as? PlainTextInputStateValue, let rhs = rhs as? PlainTextInputStateValue else { return false }
+            return lhs == rhs
+        case .radioButtons:
+            guard let lhs = lhs as? RadioButtonGroupStateValue, let rhs = rhs as? RadioButtonGroupStateValue else { return false }
+            return lhs == rhs
+        case .timepicker:
+            guard let lhs = lhs as? TimePickerStateValue, let rhs = rhs as? TimePickerStateValue else { return false }
+            return lhs == rhs
+        case .conversationsSelect:
+            guard let lhs = lhs as? SelectMenuConversationsListStateValue, let rhs = rhs as? SelectMenuConversationsListStateValue else { return false }
+            return lhs == rhs
+        case .usersSelect:
+            guard let lhs = lhs as? SelectMenuUserListStateValue, let rhs = rhs as? SelectMenuUserListStateValue else { return false }
+            return lhs == rhs
+        case .staticSelect:
+            guard let lhs = lhs as? SelectMenuStaticOptionsStateValue, let rhs = rhs as? SelectMenuStaticOptionsStateValue else { return false }
+            return lhs == rhs
+        case .channelsSelect:
+            guard let lhs = lhs as? SelectMenuPublicChannelsListStateValue, let rhs = rhs as? SelectMenuPublicChannelsListStateValue else { return false }
+            return lhs == rhs
+        case .multiConversationsSelect:
+            guard let lhs = lhs as? MultiSelectMenuConversationsListStateValue, let rhs = rhs as? MultiSelectMenuConversationsListStateValue else { return false }
+            return lhs == rhs
+        case .multiStaticSelect:
+            guard let lhs = lhs as? MultiSelectMenuStaticOptionsStateValue, let rhs = rhs as? MultiSelectMenuStaticOptionsStateValue else { return false }
+            return lhs == rhs
+        case .multiChannelsSelect:
+            guard let lhs = lhs as? MultiSelectMenuPublicChannelsListStateValue, let rhs = rhs as? MultiSelectMenuPublicChannelsListStateValue else { return false }
+            return lhs == rhs
+        case .multiUsersSelect:
+            guard let lhs = lhs as? MultiSelectMenuUserListStateValue, let rhs = rhs as? MultiSelectMenuUserListStateValue else { return false }
+            return lhs == rhs
+        }
+    }
+}
+
+public extension StateValues {
+    func isEqual(to rhs: StateValues?) -> Bool {
+        let lhs = self
+        guard let rhs = rhs else { return false }
+        guard lhs.keys.count == rhs.keys.count else { return false }
+        return lhs.allSatisfy { blockId, lhsActionDict in
+            guard let rhsActionDict = rhs[blockId] else { return false }
+            guard lhsActionDict.keys.count == rhsActionDict.keys.count else { return false }
+            return lhsActionDict.allSatisfy { actionId, lhsStateValue in
+                guard let rhsStateValue = rhsActionDict[actionId] else { return false }
+                return lhsStateValue.isEqual(to: rhsStateValue)
+            }
+        }
+    }
+}

--- a/Sources/SlackBlockKit/StateValues/UtilTypes/StateValueSelectedOption.swift
+++ b/Sources/SlackBlockKit/StateValues/UtilTypes/StateValueSelectedOption.swift
@@ -3,7 +3,7 @@ public struct StateValueSelectedOption: Codable, Equatable {
     public let value: String
     public let description: TextObject?
     
-    public init(text: TextObject, value: String, description: TextObject?) {
+    public init(text: TextObject, value: String, description: TextObject? = nil) {
         self.text = text
         self.value = value
         self.description = description

--- a/Sources/SlackBlockKit/StateValues/UtilTypes/StateValueSelectedOption.swift
+++ b/Sources/SlackBlockKit/StateValues/UtilTypes/StateValueSelectedOption.swift
@@ -1,0 +1,11 @@
+public struct StateValueSelectedOption: Codable {
+    public let text: TextObject
+    public let value: String
+    public let description: TextObject?
+    
+    public init(text: TextObject, value: String, description: TextObject?) {
+        self.text = text
+        self.value = value
+        self.description = description
+    }
+}

--- a/Sources/SlackBlockKit/StateValues/UtilTypes/StateValueSelectedOption.swift
+++ b/Sources/SlackBlockKit/StateValues/UtilTypes/StateValueSelectedOption.swift
@@ -1,4 +1,4 @@
-public struct StateValueSelectedOption: Codable {
+public struct StateValueSelectedOption: Codable, Equatable {
     public let text: TextObject
     public let value: String
     public let description: TextObject?

--- a/Sources/SlackBlockKit/StateValues/UtilTypes/StateValueType.swift
+++ b/Sources/SlackBlockKit/StateValues/UtilTypes/StateValueType.swift
@@ -4,10 +4,12 @@ public enum StateValueType: String, Codable {
     case plainTextInput = "plain_text_input"
     case radioButtons = "radio_buttons"
     case timepicker
+    // menu select types
     case conversationsSelect = "conversations_select"
     case usersSelect = "users_select"
     case staticSelect = "static_select"
     case channelsSelect = "channels_select"
+    // menu multi-select types
     case multiConversationsSelect = "multi_conversations_select"
     case multiStaticSelect = "multi_static_select"
     case multiChannelsSelect = "multi_channels_select"
@@ -17,6 +19,9 @@ public enum StateValueType: String, Codable {
         switch self {
         case .checkboxes: return CheckboxGroupsStateValue.self
         case .datepicker: return DatePickerStateValue.self
+        case .plainTextInput: return PlainTextInputStateValue.self
+        case .radioButtons: return RadioButtonGroupStateValue.self
+        case .timepicker: return TimePickerStateValue.self
         case .conversationsSelect: return SelectMenuConversationsListStateValue.self
         case .usersSelect: return SelectMenuUserListStateValue.self
         case .staticSelect: return SelectMenuStaticOptionsStateValue.self
@@ -25,9 +30,6 @@ public enum StateValueType: String, Codable {
         case .multiStaticSelect: return MultiSelectMenuStaticOptionsStateValue.self
         case .multiChannelsSelect: return MultiSelectMenuPublicChannelsListStateValue.self
         case .multiUsersSelect: return MultiSelectMenuUserListStateValue.self
-        case .plainTextInput: return PlainTextInputStateValue.self
-        case .radioButtons: return RadioButtonGroupStateValue.self
-        case .timepicker: return TimePickerStateValue.self
         }
     }
 }

--- a/Sources/SlackBlockKit/StateValues/UtilTypes/StateValueType.swift
+++ b/Sources/SlackBlockKit/StateValues/UtilTypes/StateValueType.swift
@@ -1,0 +1,33 @@
+public enum StateValueType: String, Codable {
+    case checkboxes
+    case datepicker
+    case plainTextInput = "plain_text_input"
+    case radioButtons = "radio_buttons"
+    case timepicker
+    case conversationsSelect = "conversations_select"
+    case usersSelect = "users_select"
+    case staticSelect = "static_select"
+    case channelsSelect = "channels_select"
+    case multiConversationsSelect = "multi_conversations_select"
+    case multiStaticSelect = "multi_static_select"
+    case multiChannelsSelect = "multi_channels_select"
+    case multiUsersSelect = "multi_users_select"
+    
+    var eventMetaType: StateValue.Type {
+        switch self {
+        case .checkboxes: return CheckboxGroupsStateValue.self
+        case .datepicker: return DatePickerStateValue.self
+        case .conversationsSelect: return SelectMenuConversationsListStateValue.self
+        case .usersSelect: return SelectMenuUserListStateValue.self
+        case .staticSelect: return SelectMenuStaticOptionsStateValue.self
+        case .channelsSelect: return SelectMenuPublicChannelsListStateValue.self
+        case .multiConversationsSelect: return MultiSelectMenuConversationsListStateValue.self
+        case .multiStaticSelect: return MultiSelectMenuStaticOptionsStateValue.self
+        case .multiChannelsSelect: return MultiSelectMenuPublicChannelsListStateValue.self
+        case .multiUsersSelect: return MultiSelectMenuUserListStateValue.self
+        case .plainTextInput: return PlainTextInputStateValue.self
+        case .radioButtons: return RadioButtonGroupStateValue.self
+        case .timepicker: return TimePickerStateValue.self
+        }
+    }
+}

--- a/Sources/SlackBlockKit/StateValues/UtilTypes/ViewState.swift
+++ b/Sources/SlackBlockKit/StateValues/UtilTypes/ViewState.swift
@@ -1,0 +1,30 @@
+public struct ViewState: Codable, Equatable {
+    public static func == (lhs: ViewState, rhs: ViewState) -> Bool {
+        return lhs.values.isEqual(to: rhs.values)
+    }
+    
+    /// A dictionary of objects. Each object represents a block in the source view that contained
+    /// stateful, interactive components. Objects are keyed by the `block_id` of those blocks.
+    /// These objects each contain a child object. The child object is keyed by the `action_id` of
+    /// the interactive element in the block. This final child object will contain the `type` and
+    /// submitted `value` of the input block element.
+    public let values: StateValues
+    
+    public init(values: StateValues) {
+        self.values = values
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.values = try container.decode(AnyStateValues.self, forKey: .values).mapValues { $0.mapValues(\.value) }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(values.mapValues { $0.mapValues(AnyStateValue.init) }, forKey: .values)
+    }
+    
+    public enum CodingKeys: String, CodingKey {
+        case values
+    }
+}

--- a/Sources/SlackBlockKit/Views/HomeTabView.swift
+++ b/Sources/SlackBlockKit/Views/HomeTabView.swift
@@ -24,7 +24,7 @@ public struct HomeTabView: SlackView, Equatable {
     /// submitted `value` of the input block element.
     ///
     /// This is primarily defined when decoding an event coming from Slack.
-    public var state: StateValues?
+    public var state: ViewState?
     
     public init(
         blocks: [LayoutBlock],
@@ -50,7 +50,7 @@ public struct HomeTabView: SlackView, Equatable {
         self.privateMetadata = try container.decodeIfPresent(String.self, forKey: .privateMetadata)
         self.callbackId = try container.decodeIfPresent(String.self, forKey: .callbackId)
         self.externalId = try container.decodeIfPresent(String.self, forKey: .externalId)
-        self.state = try container.decodeIfPresent(AnyStateValues.self, forKey: .state)?.mapValues { $0.mapValues(\.value) }
+        self.state = try container.decodeIfPresent(ViewState.self, forKey: .state)
     }
     
     public func encode(to encoder: Encoder) throws {
@@ -60,9 +60,7 @@ public struct HomeTabView: SlackView, Equatable {
         try container.encodeIfPresent(privateMetadata, forKey: .privateMetadata)
         try container.encodeIfPresent(callbackId, forKey: .callbackId)
         try container.encodeIfPresent(externalId, forKey: .externalId)
-        
-        let anyState = state?.mapValues { $0.mapValues(AnyStateValue.init) }
-        try container.encodeIfPresent(anyState, forKey: .state)
+        try container.encodeIfPresent(state, forKey: .state)
     }
     
     public static func == (lhs: HomeTabView, rhs: HomeTabView) -> Bool {
@@ -75,7 +73,7 @@ public struct HomeTabView: SlackView, Equatable {
             lhs.privateMetadata == rhs.privateMetadata &&
             lhs.callbackId == rhs.callbackId &&
             lhs.externalId == rhs.externalId &&
-            lhs.state?.isEqual(to: rhs.state) ?? (rhs.state == nil)
+            lhs.state == rhs.state
     }
     
     public enum CodingKeys: String, CodingKey {

--- a/Sources/SlackBlockKit/Views/HomeTabView.swift
+++ b/Sources/SlackBlockKit/Views/HomeTabView.swift
@@ -56,7 +56,7 @@ public struct HomeTabView: SlackView, Equatable {
     public static func == (lhs: HomeTabView, rhs: HomeTabView) -> Bool {
         guard lhs.blocks.count == rhs.blocks.count else { return false }
         for (index, block) in lhs.blocks.enumerated() {
-            guard isEqual(lhs: block, rhs: rhs.blocks[index]) else { return false }
+            guard block.isEqual(to: rhs.blocks[index]) else { return false }
         }
         return
             lhs.type == rhs.type &&

--- a/Sources/SlackBlockKit/Views/HomeTabView.swift
+++ b/Sources/SlackBlockKit/Views/HomeTabView.swift
@@ -17,6 +17,14 @@ public struct HomeTabView: SlackView, Equatable {
     public let callbackId: String?
     /// A custom identifier that must be unique for all views on a per-team basis.
     public let externalId: String?
+    /// A dictionary of objects. Each object represents a block in the source view that contained
+    /// stateful, interactive components. Objects are keyed by the `block_id` of those blocks.
+    /// These objects each contain a child object. The child object is keyed by the `action_id` of
+    /// the interactive element in the block. This final child object will contain the `type` and
+    /// submitted `value` of the input block element.
+    ///
+    /// This is primarily defined when decoding an event coming from Slack.
+    public var state: StateValues?
     
     public init(
         blocks: [LayoutBlock],
@@ -42,6 +50,7 @@ public struct HomeTabView: SlackView, Equatable {
         self.privateMetadata = try container.decodeIfPresent(String.self, forKey: .privateMetadata)
         self.callbackId = try container.decodeIfPresent(String.self, forKey: .callbackId)
         self.externalId = try container.decodeIfPresent(String.self, forKey: .externalId)
+        self.state = try container.decodeIfPresent(AnyStateValues.self, forKey: .state)?.mapValues { $0.mapValues(\.value) }
     }
     
     public func encode(to encoder: Encoder) throws {
@@ -51,6 +60,9 @@ public struct HomeTabView: SlackView, Equatable {
         try container.encodeIfPresent(privateMetadata, forKey: .privateMetadata)
         try container.encodeIfPresent(callbackId, forKey: .callbackId)
         try container.encodeIfPresent(externalId, forKey: .externalId)
+        
+        let anyState = state?.mapValues { $0.mapValues(AnyStateValue.init) }
+        try container.encodeIfPresent(anyState, forKey: .state)
     }
     
     public static func == (lhs: HomeTabView, rhs: HomeTabView) -> Bool {
@@ -62,7 +74,8 @@ public struct HomeTabView: SlackView, Equatable {
             lhs.type == rhs.type &&
             lhs.privateMetadata == rhs.privateMetadata &&
             lhs.callbackId == rhs.callbackId &&
-            lhs.externalId == rhs.externalId
+            lhs.externalId == rhs.externalId &&
+            lhs.state?.isEqual(to: rhs.state) ?? (rhs.state == nil)
     }
     
     public enum CodingKeys: String, CodingKey {
@@ -71,5 +84,6 @@ public struct HomeTabView: SlackView, Equatable {
         case privateMetadata = "private_metadata"
         case callbackId = "callback_id"
         case externalId = "external_id"
+        case state
     }
 }

--- a/Sources/SlackBlockKit/Views/HomeTabView.swift
+++ b/Sources/SlackBlockKit/Views/HomeTabView.swift
@@ -25,6 +25,11 @@ public struct HomeTabView: SlackView, Equatable {
     ///
     /// This is primarily defined when decoding an event coming from Slack.
     public var state: ViewState?
+    /// A unique value which is optionally accepted in views.update and views.publish API calls.
+    /// When provided to those APIs, the `hash` is validated such that only the most recent view can
+    /// be updated. This should be used to ensure the correct view is being updated when updates
+    /// are happening asynchronously.
+    public var hash: String?
     
     public init(
         blocks: [LayoutBlock],
@@ -51,6 +56,7 @@ public struct HomeTabView: SlackView, Equatable {
         self.callbackId = try container.decodeIfPresent(String.self, forKey: .callbackId)
         self.externalId = try container.decodeIfPresent(String.self, forKey: .externalId)
         self.state = try container.decodeIfPresent(ViewState.self, forKey: .state)
+        self.hash = try container.decodeIfPresent(String.self, forKey: .hash)
     }
     
     public func encode(to encoder: Encoder) throws {
@@ -61,6 +67,7 @@ public struct HomeTabView: SlackView, Equatable {
         try container.encodeIfPresent(callbackId, forKey: .callbackId)
         try container.encodeIfPresent(externalId, forKey: .externalId)
         try container.encodeIfPresent(state, forKey: .state)
+        try container.encodeIfPresent(hash, forKey: .hash)
     }
     
     public static func == (lhs: HomeTabView, rhs: HomeTabView) -> Bool {
@@ -73,7 +80,8 @@ public struct HomeTabView: SlackView, Equatable {
             lhs.privateMetadata == rhs.privateMetadata &&
             lhs.callbackId == rhs.callbackId &&
             lhs.externalId == rhs.externalId &&
-            lhs.state == rhs.state
+            lhs.state == rhs.state &&
+            lhs.hash == rhs.hash
     }
     
     public enum CodingKeys: String, CodingKey {
@@ -83,5 +91,6 @@ public struct HomeTabView: SlackView, Equatable {
         case callbackId = "callback_id"
         case externalId = "external_id"
         case state
+        case hash
     }
 }

--- a/Sources/SlackBlockKit/Views/ModalView.swift
+++ b/Sources/SlackBlockKit/Views/ModalView.swift
@@ -96,7 +96,7 @@ public struct ModalView: SlackView, Equatable {
     public static func == (lhs: ModalView, rhs: ModalView) -> Bool {
         guard lhs.blocks.count == rhs.blocks.count else { return false }
         for (index, block) in lhs.blocks.enumerated() {
-            guard isEqual(lhs: block, rhs: rhs.blocks[index]) else { return false }
+            guard block.isEqual(to: rhs.blocks[index]) else { return false }
         }
         return
             lhs.type == rhs.type &&

--- a/Sources/SlackBlockKit/Views/ModalView.swift
+++ b/Sources/SlackBlockKit/Views/ModalView.swift
@@ -50,6 +50,20 @@ public struct ModalView: SlackView, Equatable {
     /// be updated. This should be used to ensure the correct view is being updated when updates
     /// are happening asynchronously.
     public var hash: String?
+    /// The unique identifier for the application this event is intended for. Your application's
+    /// ID can be found in the URL of the your application console. If your Request URL manages
+    /// multiple applications, use this field along with the `token` field to validate and route
+    /// incoming requests.
+    public var appId: String?
+    
+    // The following properties are included when the modal is part of an event being sent by Slack.
+    // I do not have documentation for each of these properties.
+    public var appInstalledTeamId: String?
+    public var botId: String?
+    public var id: String?
+    public var previousViewId: String?
+    public var rootViewId: String?
+    public var teamId: String?
     
     public init(
         title: TextObject,
@@ -92,6 +106,13 @@ public struct ModalView: SlackView, Equatable {
         self.externalId = try container.decodeIfPresent(String.self, forKey: .externalId)
         self.state = try container.decodeIfPresent(ViewState.self, forKey: .state)
         self.hash = try container.decodeIfPresent(String.self, forKey: .hash)
+        self.appId = try container.decodeIfPresent(String.self, forKey: .appId)
+        self.appInstalledTeamId = try container.decodeIfPresent(String.self, forKey: .appInstalledTeamId)
+        self.botId = try container.decodeIfPresent(String.self, forKey: .botId)
+        self.id = try container.decodeIfPresent(String.self, forKey: .id)
+        self.previousViewId = try container.decodeIfPresent(String.self, forKey: .previousViewId)
+        self.rootViewId = try container.decodeIfPresent(String.self, forKey: .rootViewId)
+        self.teamId = try container.decodeIfPresent(String.self, forKey: .teamId)
     }
     
     public func encode(to encoder: Encoder) throws {
@@ -108,6 +129,13 @@ public struct ModalView: SlackView, Equatable {
         try container.encodeIfPresent(externalId, forKey: .externalId)
         try container.encodeIfPresent(state, forKey: .state)
         try container.encodeIfPresent(hash, forKey: .hash)
+        try container.encodeIfPresent(appId, forKey: .appId)
+        try container.encodeIfPresent(appInstalledTeamId, forKey: .appInstalledTeamId)
+        try container.encodeIfPresent(botId, forKey: .botId)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(previousViewId, forKey: .previousViewId)
+        try container.encodeIfPresent(rootViewId, forKey: .rootViewId)
+        try container.encodeIfPresent(teamId, forKey: .teamId)
     }
     
     public static func == (lhs: ModalView, rhs: ModalView) -> Bool {
@@ -126,7 +154,14 @@ public struct ModalView: SlackView, Equatable {
             lhs.notifyOnClose == rhs.notifyOnClose &&
             lhs.externalId == rhs.externalId &&
             lhs.state == rhs.state &&
-            lhs.hash == rhs.hash
+            lhs.hash == rhs.hash &&
+            lhs.appId == rhs.appId &&
+            lhs.appInstalledTeamId == rhs.appInstalledTeamId &&
+            lhs.botId == rhs.botId &&
+            lhs.id == rhs.id &&
+            lhs.previousViewId == rhs.previousViewId &&
+            lhs.rootViewId == rhs.rootViewId &&
+            lhs.teamId == rhs.teamId
     }
     
     public enum CodingKeys: String, CodingKey {
@@ -142,5 +177,12 @@ public struct ModalView: SlackView, Equatable {
         case externalId = "external_id"
         case state
         case hash
+        case appId = "app_id"
+        case appInstalledTeamId = "app_installed_team_id"
+        case botId = "bot_id"
+        case id
+        case previousViewId = "previous_view_id"
+        case rootViewId = "root_view_id"
+        case teamId = "team_id"
     }
 }

--- a/Sources/SlackBlockKit/Views/UtilTypes/SlackView.swift
+++ b/Sources/SlackBlockKit/Views/UtilTypes/SlackView.swift
@@ -6,4 +6,5 @@ public protocol SlackView: Codable {
     static var type: SlackViewType { get }
     var type: String { get }
     var blocks: [LayoutBlock] { get }
+    var hash: String? { get set }
 }

--- a/Tests/SlackBlockKitTests/Events/AppHomeOpenedEventTests.swift
+++ b/Tests/SlackBlockKitTests/Events/AppHomeOpenedEventTests.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Robert Galluccio on 02/01/2021.
+//
+
+import Foundation

--- a/Tests/SlackBlockKitTests/Events/AppHomeOpenedEventTests.swift
+++ b/Tests/SlackBlockKitTests/Events/AppHomeOpenedEventTests.swift
@@ -1,8 +1,72 @@
-//
-//  File.swift
-//  
-//
-//  Created by Robert Galluccio on 02/01/2021.
-//
+import SlackBlockKit
+import XCTest
 
-import Foundation
+let appHomeOpened = """
+{
+  "type": "app_home_opened",
+  "user": "U061F7AUR",
+  "event_ts": "1515449522000016",
+  "tab": "home",
+  "view": {
+    "type": "home",
+    "blocks": [
+      {
+        "accessory": {
+          "action_id": "home-action-1234",
+          "type": "plain_text_input"
+        },
+        "block_id": "home-1234",
+        "text": {
+          "text": "test-text",
+          "type": "plain_text"
+        },
+        "type": "section"
+      }
+    ],
+    "private_metadata": "",
+    "callback_id": "",
+    "state": {
+      "values": {
+        "home-1234": {
+          "home-action-1234": {
+            "type": "plain_text_input",
+            "value": "test-input"
+          }
+        }
+      }
+    },
+    "external_id": ""
+  }
+}
+"""
+
+class AppHomeOpenedEventTests: BlockTestCase {
+    func test_appHomeOpened() throws {
+        var homeTabView = HomeTabView(
+            blocks: [
+                SectionBlock(
+                    text: TextObject(type: .plainText, text: "test-text"),
+                    blockId: "home-1234",
+                    accessory: PlainTextInputElement(actionId: "home-action-1234")
+                )
+            ],
+            privateMetadata: "",
+            callbackId: "",
+            externalId: ""
+        )
+        homeTabView.state = ViewState(
+            values: [
+                "home-1234": [
+                    "home-action-1234": PlainTextInputStateValue(value: "test-input")
+                ]
+            ]
+        )
+        let appHomeOpenedEvent = AppHomeOpenedEvent(
+            user: "U061F7AUR",
+            eventTs: "1515449522000016",
+            tab: "home",
+            view: homeTabView
+        )
+        testCodableEquality(event: appHomeOpenedEvent, jsonString: appHomeOpened)
+    }
+}

--- a/Tests/SlackBlockKitTests/Events/SlackEventCallbackTests.swift
+++ b/Tests/SlackBlockKitTests/Events/SlackEventCallbackTests.swift
@@ -1,0 +1,104 @@
+import SlackBlockKit
+
+private let eventCallback = """
+{
+  "token": "XXYYZZ",
+  "team_id": "TXXXXXXXX",
+  "api_app_id": "AXXXXXXXXX",
+  "event": {
+    "type": "app_home_opened",
+    "user": "U061F7AUR",
+    "event_ts": "1515449522000016",
+    "tab": "home",
+    "view": {
+      "type": "home",
+      "blocks": [
+        {
+          "accessory": {
+            "action_id": "home-action-1234",
+            "type": "plain_text_input"
+          },
+          "block_id": "home-1234",
+          "text": {
+            "text": "test-text",
+            "type": "plain_text"
+          },
+          "type": "section"
+        }
+      ],
+      "private_metadata": "",
+      "callback_id": "",
+      "state": {
+        "values": {
+          "home-1234": {
+            "home-action-1234": {
+              "type": "plain_text_input",
+              "value": "test-input"
+            }
+          }
+        }
+      },
+      "external_id": ""
+    }
+  },
+  "type": "event_callback",
+  "authed_users": [
+    "UXXXXXXX1"
+  ],
+  "authed_teams": [
+    "TXXXXXXXX"
+  ],
+  "authorizations": {
+    "enterprise_id": "E12345",
+    "team_id": "T12345",
+    "user_id": "U12345",
+    "is_bot": false
+  },
+  "event_context": "EC12345",
+  "event_id": "Ev08MFMKH6",
+  "event_time": 1234567890
+}
+"""
+
+class SlackEventCallbackTests: BlockTestCase {
+    func test_slackEventCallback_withAppHomeOpened() {
+        var homeTabView = HomeTabView(
+            blocks: [
+                SectionBlock(
+                    text: TextObject(type: .plainText, text: "test-text"),
+                    blockId: "home-1234",
+                    accessory: PlainTextInputElement(actionId: "home-action-1234")
+                )
+            ],
+            privateMetadata: "",
+            callbackId: "",
+            externalId: ""
+        )
+        homeTabView.state = ViewState(
+            values: [
+                "home-1234": [
+                    "home-action-1234": PlainTextInputStateValue(value: "test-input")
+                ]
+            ]
+        )
+        let appHomeOpenedEvent = AppHomeOpenedEvent(
+            user: "U061F7AUR",
+            eventTs: "1515449522000016",
+            tab: "home",
+            view: homeTabView
+        )
+        let slackEventCallback = SlackEventCallback(
+            token: "XXYYZZ",
+            teamId: "TXXXXXXXX",
+            event: appHomeOpenedEvent,
+            eventId: "Ev08MFMKH6",
+            eventTime: 1234567890,
+            apiAppId: "AXXXXXXXXX",
+            authedUsers: ["UXXXXXXX1"],
+            authedTeams: ["TXXXXXXXX"],
+            authorizations: SlackAuthorizations(enterpriseId: "E12345", teamId: "T12345", userId: "U12345", isBot: false),
+            eventContext: "EC12345"
+        )
+        testCodableEquality(event: slackEventCallback, jsonString: eventCallback)
+    }
+}

--- a/Tests/SlackBlockKitTests/Events/URLVerificationEventTests.swift
+++ b/Tests/SlackBlockKitTests/Events/URLVerificationEventTests.swift
@@ -1,0 +1,20 @@
+import SlackBlockKit
+
+// https://api.slack.com/events-api#the-events-api__subscribing-to-event-types__events-api-request-urls__request-url-configuration--verification__url-verification-handshake
+private let urlVerification = """
+{
+    "token": "Jhj5dZrVaK7ZwHHjRyZWjbDl",
+    "challenge": "3eZbrw1aBm2rZgRNFdxV2595E9CY3gmdALWMmHkvFXO7tYXAYM8P",
+    "type": "url_verification"
+}
+"""
+
+class URLVerificationEventTests: BlockTestCase {
+    func test_urlVerificationEvent() {
+        let urlVerificationEvent = URLVerificationEvent(
+            token: "Jhj5dZrVaK7ZwHHjRyZWjbDl",
+            challenge: "3eZbrw1aBm2rZgRNFdxV2595E9CY3gmdALWMmHkvFXO7tYXAYM8P"
+        )
+        testCodableEquality(event: urlVerificationEvent, jsonString: urlVerification)
+    }
+}

--- a/Tests/SlackBlockKitTests/Events/ViewClosedEventTests.swift
+++ b/Tests/SlackBlockKitTests/Events/ViewClosedEventTests.swift
@@ -1,0 +1,149 @@
+import SlackBlockKit
+
+// https://api.slack.com/reference/interaction-payloads/views#view_closed__example
+private let viewSubmission = """
+{
+  "type": "view_closed",
+  "team": {
+    "id": "TXXXXXX",
+    "domain": "coverbands"
+  },
+  "user": {
+    "id": "UXXXXXX",
+    "name": "dreamweaver"
+  },
+  "token": "Shh_its_a_seekrit",
+  "view": {
+    "id": "V1234567890",
+    "team_id": "T01ER49MBU2",
+    "type": "modal",
+    "blocks": [
+      {
+        "type": "input",
+        "block_id": "zCB",
+        "label": {
+          "type": "plain_text",
+          "text": "Label",
+          "emoji": true
+        },
+        "optional": false,
+        "dispatch_action": false,
+        "element": {
+          "type": "plain_text_input",
+          "action_id": "plain_text_input-action",
+          "dispatch_action_config": {
+            "trigger_actions_on": [
+              "on_enter_pressed"
+            ]
+          }
+        }
+      }
+    ],
+    "private_metadata": "",
+    "callback_id": "",
+    "state": {
+      "values": {
+        "zCB": {
+          "plain_text_input-action": {
+            "type": "plain_text_input",
+            "value": "Test input."
+          }
+        }
+      }
+    },
+    "hash": "1609700657.dL8yRBeO",
+    "title": {
+      "type": "plain_text",
+      "text": "My App",
+      "emoji": true
+    },
+    "clear_on_close": false,
+    "notify_on_close": false,
+    "close": {
+      "type": "plain_text",
+      "text": "Cancel",
+      "emoji": true
+    },
+    "submit": {
+      "type": "plain_text",
+      "text": "Submit",
+      "emoji": true
+    },
+    "root_view_id": "V1234567890",
+    "app_id": "A02",
+    "external_id": "",
+    "app_installed_team_id": "T01ER49MBU2",
+    "bot_id": "B00"
+  },
+  "api_app_id": "AXXXXXX",
+  "is_cleared": false
+}
+"""
+
+class ViewClosedEventTests: BlockTestCase {
+    func test_viewClosedEvent() {
+        var modalView = ModalView(
+            title: TextObject(
+                type: .plainText,
+                text: "My App",
+                emoji: true
+            ),
+            blocks: [
+                InputBlock(
+                    label: TextObject(
+                        type: .plainText,
+                        text: "Label",
+                        emoji: true
+                    ),
+                    element: PlainTextInputElement(
+                        actionId: "plain_text_input-action",
+                        dispatchActionConfig: DispatchActionConfiguration(
+                            triggerActionsOn: [.onEnterPressed]
+                        )
+                    ),
+                    dispatchAction: false,
+                    blockId: "zCB",
+                    optional: false
+                )
+            ],
+            close: TextObject(
+                type: .plainText,
+                text: "Cancel",
+                emoji: true
+            ),
+            submit: TextObject(
+                type: .plainText,
+                text: "Submit",
+                emoji: true
+            ),
+            privateMetadata: "",
+            callbackId: "",
+            clearOnClose: false,
+            notifyOnClose: false,
+            externalId: ""
+        )
+        modalView.state = ViewState(
+            values: [
+                "zCB": [
+                    "plain_text_input-action": PlainTextInputStateValue(value: "Test input.")
+                ]
+            ]
+        )
+        modalView.hash = "1609700657.dL8yRBeO"
+        modalView.appId = "A02"
+        modalView.appInstalledTeamId = "T01ER49MBU2"
+        modalView.botId = "B00"
+        modalView.id = "V1234567890"
+        modalView.rootViewId = "V1234567890"
+        modalView.teamId = "T01ER49MBU2"
+        var viewSubmissionEvent = ViewClosedEvent(
+            token: "Shh_its_a_seekrit",
+            team: SlackTeam(id: "TXXXXXX", domain: "coverbands"),
+            user: SlackUser(id: "UXXXXXX", name: "dreamweaver"),
+            view: modalView,
+            isCleared: false
+        )
+        viewSubmissionEvent.apiAppId = "AXXXXXX"
+        testCodableEquality(event: viewSubmissionEvent, jsonString: viewSubmission)
+    }
+}

--- a/Tests/SlackBlockKitTests/Events/ViewSubmissionEventTests.swift
+++ b/Tests/SlackBlockKitTests/Events/ViewSubmissionEventTests.swift
@@ -1,0 +1,159 @@
+import SlackBlockKit
+
+private let viewSubmission = """
+{
+  "type": "view_submission",
+  "team": {
+    "id": "T01ER49MBU2",
+    "domain": "spaceforapptesting"
+  },
+  "user": {
+    "id": "U01ERACBV43",
+    "username": "robert.galluccio",
+    "name": "robert.galluccio",
+    "team_id": "T01ER49MBU2"
+  },
+  "api_app_id": "A02",
+  "token": "Shh_its_a_seekrit",
+  "trigger_id": "123456789.123456789",
+  "view": {
+    "id": "V1234567890",
+    "team_id": "T01ER49MBU2",
+    "type": "modal",
+    "blocks": [
+      {
+        "type": "input",
+        "block_id": "zCB",
+        "label": {
+          "type": "plain_text",
+          "text": "Label",
+          "emoji": true
+        },
+        "optional": false,
+        "dispatch_action": false,
+        "element": {
+          "type": "plain_text_input",
+          "action_id": "plain_text_input-action",
+          "dispatch_action_config": {
+            "trigger_actions_on": [
+              "on_enter_pressed"
+            ]
+          }
+        }
+      }
+    ],
+    "private_metadata": "",
+    "callback_id": "",
+    "state": {
+      "values": {
+        "zCB": {
+          "plain_text_input-action": {
+            "type": "plain_text_input",
+            "value": "Test input."
+          }
+        }
+      }
+    },
+    "hash": "1609700657.dL8yRBeO",
+    "title": {
+      "type": "plain_text",
+      "text": "My App",
+      "emoji": true
+    },
+    "clear_on_close": false,
+    "notify_on_close": false,
+    "close": {
+      "type": "plain_text",
+      "text": "Cancel",
+      "emoji": true
+    },
+    "submit": {
+      "type": "plain_text",
+      "text": "Submit",
+      "emoji": true
+    },
+    "root_view_id": "V1234567890",
+    "app_id": "A02",
+    "external_id": "",
+    "app_installed_team_id": "T01ER49MBU2",
+    "bot_id": "B00"
+  },
+  "response_urls": [],
+  "is_enterprise_install": false
+}
+"""
+
+class ViewSubmissionEventTests: BlockTestCase {
+    func test_viewSubmissionEvent() {
+        var modalView = ModalView(
+            title: TextObject(
+                type: .plainText,
+                text: "My App",
+                emoji: true
+            ),
+            blocks: [
+                InputBlock(
+                    label: TextObject(
+                        type: .plainText,
+                        text: "Label",
+                        emoji: true
+                    ),
+                    element: PlainTextInputElement(
+                        actionId: "plain_text_input-action",
+                        dispatchActionConfig: DispatchActionConfiguration(
+                            triggerActionsOn: [.onEnterPressed]
+                        )
+                    ),
+                    dispatchAction: false,
+                    blockId: "zCB",
+                    optional: false
+                )
+            ],
+            close: TextObject(
+                type: .plainText,
+                text: "Cancel",
+                emoji: true
+            ),
+            submit: TextObject(
+                type: .plainText,
+                text: "Submit",
+                emoji: true
+            ),
+            privateMetadata: "",
+            callbackId: "",
+            clearOnClose: false,
+            notifyOnClose: false,
+            externalId: ""
+        )
+        modalView.state = ViewState(
+            values: [
+                "zCB": [
+                    "plain_text_input-action": PlainTextInputStateValue(value: "Test input.")
+                ]
+            ]
+        )
+        modalView.hash = "1609700657.dL8yRBeO"
+        modalView.appId = "A02"
+        modalView.appInstalledTeamId = "T01ER49MBU2"
+        modalView.botId = "B00"
+        modalView.id = "V1234567890"
+        modalView.rootViewId = "V1234567890"
+        modalView.teamId = "T01ER49MBU2"
+        var viewSubmissionEvent = ViewSubmissionEvent(
+            token: "Shh_its_a_seekrit",
+            team: SlackTeam(id: "T01ER49MBU2", domain: "spaceforapptesting"),
+            user: SlackUser(
+                id: "U01ERACBV43",
+                username: "robert.galluccio",
+                name: "robert.galluccio",
+                teamId: "T01ER49MBU2"
+            ),
+            view: modalView
+        )
+        viewSubmissionEvent.apiAppId = "A02"
+        viewSubmissionEvent.isEnterpriseInstall = false
+        viewSubmissionEvent.responseUrls = []
+        viewSubmissionEvent.triggerId = "123456789.123456789"
+        testCodableEquality(event: viewSubmissionEvent, jsonString: viewSubmission)
+    }
+}

--- a/Tests/SlackBlockKitTests/StateValues/CheckboxGroupsStateValueTests.swift
+++ b/Tests/SlackBlockKitTests/StateValues/CheckboxGroupsStateValueTests.swift
@@ -1,0 +1,97 @@
+import SlackBlockKit
+import XCTest
+
+private let checkboxNoSelection = """
+{
+  "type": "checkboxes",
+  "selected_options": []
+}
+"""
+
+private let checkboxSingleSelection = """
+{
+  "type": "checkboxes",
+  "selected_options": [
+    {
+      "text": {
+        "type": "mrkdwn",
+        "text": "*this is mrkdwn text*",
+        "verbatim": false
+      },
+      "value": "value-1",
+      "description": {
+        "type": "mrkdwn",
+        "text": "*this is mrkdwn text*",
+        "verbatim": false
+      }
+    }
+  ]
+}
+"""
+
+private let checkboxMultiSelection = """
+{
+  "type": "checkboxes",
+  "selected_options": [
+    {
+      "text": {
+        "type": "mrkdwn",
+        "text": "*this is mrkdwn text*"
+      },
+      "value": "value-0"
+    },
+    {
+      "text": {
+        "type": "mrkdwn",
+        "text": "*this is mrkdwn text*"
+      },
+      "value": "value-1"
+    }
+  ]
+}
+"""
+
+class CheckboxGroupsStateValueTests: XCTestCase {
+    var jsonDecoder: JSONDecoder!
+    
+    override func setUp() {
+        jsonDecoder = JSONDecoder()
+    }
+    
+    func test_checkbox_noSelection() throws {
+        let checkboxState = try jsonDecoder.decode(CheckboxGroupsStateValue.self, from: checkboxNoSelection)
+        let expectedCheckboxState = CheckboxGroupsStateValue(selectedOptions: [])
+        XCTAssertEqual(checkboxState, expectedCheckboxState)
+    }
+    
+    func test_checkbox_oneSelection() throws {
+        let checkboxState = try jsonDecoder.decode(CheckboxGroupsStateValue.self, from: checkboxSingleSelection)
+        let expectedCheckboxState = CheckboxGroupsStateValue(
+            selectedOptions: [
+                StateValueSelectedOption(
+                    text: TextObject(type: .mrkdwn, text: "*this is mrkdwn text*", verbatim: false),
+                    value: "value-1",
+                    description: TextObject(type: .mrkdwn, text: "*this is mrkdwn text*", verbatim: false)
+                )
+            ]
+        )
+        XCTAssertEqual(checkboxState, expectedCheckboxState)
+    }
+    
+    func test_checkbox_multiSelection() throws {
+        let checkboxState = try jsonDecoder.decode(CheckboxGroupsStateValue.self, from: checkboxMultiSelection)
+        let expectedCheckboxState = CheckboxGroupsStateValue(
+            selectedOptions: [
+                StateValueSelectedOption(
+                    text: TextObject(type: .mrkdwn, text: "*this is mrkdwn text*"),
+                    value: "value-0"
+                ),
+                StateValueSelectedOption(
+                    text: TextObject(type: .mrkdwn, text: "*this is mrkdwn text*"),
+                    value: "value-1"
+                )
+            ]
+        )
+        XCTAssertEqual(checkboxState, expectedCheckboxState)
+    }
+}

--- a/Tests/SlackBlockKitTests/StateValues/DatePickerStateValueTests.swift
+++ b/Tests/SlackBlockKitTests/StateValues/DatePickerStateValueTests.swift
@@ -1,0 +1,23 @@
+import SlackBlockKit
+import XCTest
+
+private let datePicker = """
+{
+  "type": "datepicker",
+  "selected_date": "1990-04-28"
+}
+"""
+
+class DatePickerStateValueTests: XCTestCase {
+    private var jsonDecoder: JSONDecoder!
+    
+    override func setUp() {
+        jsonDecoder = JSONDecoder()
+    }
+    
+    func test_datePicker() throws {
+        let datePickerState = try jsonDecoder.decode(DatePickerStateValue.self, from: datePicker)
+        let expectedDatePicker = DatePickerStateValue(selectedDate: "1990-04-28")
+        XCTAssertEqual(datePickerState, expectedDatePicker)
+    }
+}

--- a/Tests/SlackBlockKitTests/StateValues/MultiSelectMenuConversationsListStateValueTests.swift
+++ b/Tests/SlackBlockKitTests/StateValues/MultiSelectMenuConversationsListStateValueTests.swift
@@ -1,0 +1,68 @@
+import SlackBlockKit
+import XCTest
+
+private let multiSelectMenuConversationsNoSelection = """
+{
+  "type": "multi_conversations_select",
+  "selected_conversations": []
+}
+"""
+
+private let multiSelectMenuConversationsSingleSelection = """
+{
+  "type": "multi_conversations_select",
+  "selected_conversations": [
+    "C01EN1PHXFX"
+  ]
+}
+"""
+
+private let multiSelectMenuConversationsMultiSelection = """
+{
+  "type": "multi_conversations_select",
+  "selected_conversations": [
+    "C01EN1PHXFX",
+    "C01ERACCHA7",
+    "U01ERACBV43"
+  ]
+}
+"""
+
+class MultiSelectMenuConversationsListStateValueTests: XCTestCase {
+    var jsonDecoder: JSONDecoder!
+    
+    override func setUp() {
+        jsonDecoder = JSONDecoder()
+    }
+    
+    func test_multiSelectMenuConversations_noSelection() throws {
+        let multiSelectState = try jsonDecoder.decode(
+            MultiSelectMenuConversationsListStateValue.self,
+            from: multiSelectMenuConversationsNoSelection
+        )
+        let expectedState = MultiSelectMenuConversationsListStateValue(selectedConversations: [])
+        XCTAssertEqual(multiSelectState, expectedState)
+    }
+    
+    func test_multiSelectMenuConversations_oneSelection() throws {
+        let multiSelectState = try jsonDecoder.decode(
+            MultiSelectMenuConversationsListStateValue.self,
+            from: multiSelectMenuConversationsSingleSelection
+        )
+        let expectedState = MultiSelectMenuConversationsListStateValue(
+            selectedConversations: ["C01EN1PHXFX"]
+        )
+        XCTAssertEqual(multiSelectState, expectedState)
+    }
+    
+    func test_multiSelectMenuConversations_multiSelection() throws {
+        let multiSelectState = try jsonDecoder.decode(
+            MultiSelectMenuConversationsListStateValue.self,
+            from: multiSelectMenuConversationsMultiSelection
+        )
+        let expectedState = MultiSelectMenuConversationsListStateValue(
+            selectedConversations: ["C01EN1PHXFX", "C01ERACCHA7", "U01ERACBV43"]
+        )
+        XCTAssertEqual(multiSelectState, expectedState)
+    }
+}

--- a/Tests/SlackBlockKitTests/StateValues/MultiSelectMenuPublicChannelsListStateValueTests.swift
+++ b/Tests/SlackBlockKitTests/StateValues/MultiSelectMenuPublicChannelsListStateValueTests.swift
@@ -1,0 +1,67 @@
+import SlackBlockKit
+import XCTest
+
+private let multiSelectMenuChannelsNoSelection = """
+{
+  "type": "multi_channels_select",
+  "selected_channels": []
+}
+"""
+
+private let multiSelectMenuChannelsSingleSelection = """
+{
+  "type": "multi_channels_select",
+  "selected_channels": [
+    "C01EN1PHXFX"
+  ]
+}
+"""
+
+private let multiSelectMenuChannelsMultiSelection = """
+{
+  "type": "multi_channels_select",
+  "selected_channels": [
+    "C01ERACCHA7",
+    "C01EN1PHXFX"
+  ]
+}
+"""
+
+class MultiSelectMenuPublicChannelsListStateValueTests: XCTestCase {
+    var jsonDecoder: JSONDecoder!
+    
+    override func setUp() {
+        jsonDecoder = JSONDecoder()
+    }
+    
+    func test_multiSelectMenuChannels_noSelection() throws {
+        let multiSelectState = try jsonDecoder.decode(
+            MultiSelectMenuPublicChannelsListStateValue.self,
+            from: multiSelectMenuChannelsNoSelection
+        )
+        let expectedState = MultiSelectMenuPublicChannelsListStateValue(selectedChannels: [])
+        XCTAssertEqual(multiSelectState, expectedState)
+    }
+    
+    func test_multiSelectMenuChannels_oneSelection() throws {
+        let multiSelectState = try jsonDecoder.decode(
+            MultiSelectMenuPublicChannelsListStateValue.self,
+            from: multiSelectMenuChannelsSingleSelection
+        )
+        let expectedState = MultiSelectMenuPublicChannelsListStateValue(
+            selectedChannels: ["C01EN1PHXFX"]
+        )
+        XCTAssertEqual(multiSelectState, expectedState)
+    }
+    
+    func test_multiSelectMenuChannels_multiSelection() throws {
+        let multiSelectState = try jsonDecoder.decode(
+            MultiSelectMenuPublicChannelsListStateValue.self,
+            from: multiSelectMenuChannelsMultiSelection
+        )
+        let expectedState = MultiSelectMenuPublicChannelsListStateValue(
+            selectedChannels: ["C01ERACCHA7", "C01EN1PHXFX"]
+        )
+        XCTAssertEqual(multiSelectState, expectedState)
+    }
+}

--- a/Tests/SlackBlockKitTests/StateValues/MultiSelectMenuStaticOptionsStateValueTests.swift
+++ b/Tests/SlackBlockKitTests/StateValues/MultiSelectMenuStaticOptionsStateValueTests.swift
@@ -1,0 +1,97 @@
+import SlackBlockKit
+import XCTest
+
+private let multiSelectStaticOptionsNoSelection = """
+{
+  "type": "multi_static_select",
+  "selected_options": []
+}
+"""
+
+private let multiSelectStaticOptionsSingleSelection = """
+{
+  "type": "multi_static_select",
+  "selected_options": [
+    {
+      "text": {
+        "type": "plain_text",
+        "text": "this is plain text",
+        "emoji": true
+      },
+      "value": "value-2",
+      "description": {
+        "type": "plain_text",
+        "text": "this is plain text",
+        "emoji": true
+      }
+    }
+  ]
+}
+"""
+
+private let multiSelectStaticOptionsMultiSelection = """
+{
+  "type": "multi_static_select",
+  "selected_options": [
+    {
+      "text": {
+        "type": "plain_text",
+        "text": "this is plain text"
+      },
+      "value": "value-0"
+    },
+    {
+      "text": {
+        "type": "plain_text",
+        "text": "this is plain text"
+      },
+      "value": "value-2"
+    }
+  ]
+}
+"""
+
+class MultiSelectMenuStaticOptionsStateValueTests: XCTestCase {
+    var jsonDecoder: JSONDecoder!
+    
+    override func setUp() {
+        jsonDecoder = JSONDecoder()
+    }
+    
+    func test_multiSelectStaticOptions_noSelection() throws {
+        let multiSelectState = try jsonDecoder.decode(MultiSelectMenuStaticOptionsStateValue.self, from: multiSelectStaticOptionsNoSelection)
+        let expectedState = MultiSelectMenuStaticOptionsStateValue(selectedOptions: [])
+        XCTAssertEqual(multiSelectState, expectedState)
+    }
+    
+    func test_multiSelectStaticOptions_oneSelection() throws {
+        let multiSelectState = try jsonDecoder.decode(MultiSelectMenuStaticOptionsStateValue.self, from: multiSelectStaticOptionsSingleSelection)
+        let expectedState = MultiSelectMenuStaticOptionsStateValue(
+            selectedOptions: [
+                StateValueSelectedOption(
+                    text: TextObject(type: .plainText, text: "this is plain text", emoji: true),
+                    value: "value-2",
+                    description: TextObject(type: .plainText, text: "this is plain text", emoji: true)
+                )
+            ]
+        )
+        XCTAssertEqual(multiSelectState, expectedState)
+    }
+    
+    func test_multiSelectStaticOptions_multiSelection() throws {
+        let multiSelectState = try jsonDecoder.decode(MultiSelectMenuStaticOptionsStateValue.self, from: multiSelectStaticOptionsMultiSelection)
+        let expectedState = MultiSelectMenuStaticOptionsStateValue(
+            selectedOptions: [
+                StateValueSelectedOption(
+                    text: TextObject(type: .plainText, text: "this is plain text"),
+                    value: "value-0"
+                ),
+                StateValueSelectedOption(
+                    text: TextObject(type: .plainText, text: "this is plain text"),
+                    value: "value-2"
+                )
+            ]
+        )
+        XCTAssertEqual(multiSelectState, expectedState)
+    }
+}

--- a/Tests/SlackBlockKitTests/StateValues/MultiSelectMenuUserListStateValueTests.swift
+++ b/Tests/SlackBlockKitTests/StateValues/MultiSelectMenuUserListStateValueTests.swift
@@ -1,0 +1,67 @@
+import SlackBlockKit
+import XCTest
+
+private let multiSelectMenuUsersNoSelection = """
+{
+  "type": "multi_users_select",
+  "selected_users": []
+}
+"""
+
+private let multiSelectMenuUsersSingleSelection = """
+{
+  "type": "multi_users_select",
+  "selected_users": [
+    "U01ERACBV43"
+  ]
+}
+"""
+
+private let multiSelectMenuUsersMultiSelection = """
+{
+  "type": "multi_users_select",
+  "selected_users": [
+    "U01ERACBV43",
+    "USLACKBOT"
+  ]
+}
+"""
+
+class MultiSelectMenuUserListStateValueTests: XCTestCase {
+    var jsonDecoder: JSONDecoder!
+    
+    override func setUp() {
+        jsonDecoder = JSONDecoder()
+    }
+    
+    func test_multiSelectMenuUserList_noSelection() throws {
+        let multiSelectState = try jsonDecoder.decode(
+            MultiSelectMenuUserListStateValue.self,
+            from: multiSelectMenuUsersNoSelection
+        )
+        let expectedState = MultiSelectMenuUserListStateValue(selectedUsers: [])
+        XCTAssertEqual(multiSelectState, expectedState)
+    }
+    
+    func test_multiSelectMenuUserList_oneSelection() throws {
+        let multiSelectState = try jsonDecoder.decode(
+            MultiSelectMenuUserListStateValue.self,
+            from: multiSelectMenuUsersSingleSelection
+        )
+        let expectedState = MultiSelectMenuUserListStateValue(
+            selectedUsers: ["U01ERACBV43"]
+        )
+        XCTAssertEqual(multiSelectState, expectedState)
+    }
+    
+    func test_multiSelectMenuUserList_multiSelection() throws {
+        let multiSelectState = try jsonDecoder.decode(
+            MultiSelectMenuUserListStateValue.self,
+            from: multiSelectMenuUsersMultiSelection
+        )
+        let expectedState = MultiSelectMenuUserListStateValue(
+            selectedUsers: ["U01ERACBV43", "USLACKBOT"]
+        )
+        XCTAssertEqual(multiSelectState, expectedState)
+    }
+}

--- a/Tests/SlackBlockKitTests/StateValues/PlainTextInputStateValueTests.swift
+++ b/Tests/SlackBlockKitTests/StateValues/PlainTextInputStateValueTests.swift
@@ -1,0 +1,49 @@
+import SlackBlockKit
+import XCTest
+
+private let inputNoValue = """
+{
+  "type" : "plain_text_input",
+  "value" : null
+}
+"""
+
+private let inputWithValue = """
+{
+  "type" : "plain_text_input",
+  "value" : "Hello, World!"
+}
+"""
+
+class PlainTextInputStateValueTests: XCTestCase {
+    var jsonEncoder: JSONEncoder!
+    var jsonDecoder: JSONDecoder!
+    
+    override func setUp() {
+        jsonEncoder = JSONEncoder()
+        jsonEncoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        jsonDecoder = JSONDecoder()
+    }
+    
+    func test_plainTextInput_noValue_decode() throws {
+        let stateValue = try jsonDecoder.decode(PlainTextInputStateValue.self, from: inputNoValue)
+        let expectedState = PlainTextInputStateValue(value: nil)
+        XCTAssertEqual(stateValue, expectedState)
+    }
+    
+    func test_plainTextInput_noValue_encode() throws {
+        let encodedState = try jsonEncoder.encodeAsString(PlainTextInputStateValue(value: nil))
+        XCTAssertEqual(encodedState, inputNoValue)
+    }
+    
+    func test_painTextInput_withValue_decode() throws {
+        let stateValue = try jsonDecoder.decode(PlainTextInputStateValue.self, from: inputWithValue)
+        let expectedState = PlainTextInputStateValue(value: "Hello, World!")
+        XCTAssertEqual(stateValue, expectedState)
+    }
+    
+    func test_painTextInput_withValue_encode() throws {
+        let encodedState = try jsonEncoder.encodeAsString(PlainTextInputStateValue(value: "Hello, World!"))
+        XCTAssertEqual(encodedState, inputWithValue)
+    }
+}

--- a/Tests/SlackBlockKitTests/StateValues/RadioButtonGroupStateValueTests.swift
+++ b/Tests/SlackBlockKitTests/StateValues/RadioButtonGroupStateValueTests.swift
@@ -1,14 +1,14 @@
 import SlackBlockKit
 import XCTest
 
-let radioGroupNoSelection = """
+private let radioGroupNoSelection = """
 {
   "selected_option" : null,
   "type" : "radio_buttons"
 }
 """
 
-let radioGroupWithSelection = """
+private let radioGroupWithSelection = """
 {
   "selected_option" : {
     "text" : {

--- a/Tests/SlackBlockKitTests/StateValues/RadioButtonGroupStateValueTests.swift
+++ b/Tests/SlackBlockKitTests/StateValues/RadioButtonGroupStateValueTests.swift
@@ -1,0 +1,68 @@
+import SlackBlockKit
+import XCTest
+
+let radioGroupNoSelection = """
+{
+  "selected_option" : null,
+  "type" : "radio_buttons"
+}
+"""
+
+let radioGroupWithSelection = """
+{
+  "selected_option" : {
+    "text" : {
+      "emoji" : true,
+      "text" : "*this is plain_text text*",
+      "type" : "plain_text"
+    },
+    "value" : "value-2"
+  },
+  "type" : "radio_buttons"
+}
+"""
+
+class RadioButtonGroupStateValueTests: XCTestCase {
+    var jsonEncoder: JSONEncoder!
+    var jsonDecoder: JSONDecoder!
+    
+    override func setUp() {
+        jsonEncoder = JSONEncoder()
+        jsonEncoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        jsonDecoder = JSONDecoder()
+    }
+    
+    func test_radioGroup_noSelection_encode() throws {
+        let radioGroup = try jsonEncoder.encodeAsString(RadioButtonGroupStateValue(selectedOption: nil))
+        XCTAssertEqual(radioGroup, radioGroupNoSelection)
+    }
+    
+    func test_radioGroup_noSelection_decode() throws {
+        let expectedRadioGroup = RadioButtonGroupStateValue(selectedOption: nil)
+        let radioGroup = try jsonDecoder.decode(RadioButtonGroupStateValue.self, from: radioGroupNoSelection)
+        XCTAssertEqual(radioGroup, expectedRadioGroup)
+    }
+    
+    func test_radioGroup_withSelection_encode() throws {
+        let radioGroup = try jsonEncoder.encodeAsString(
+            RadioButtonGroupStateValue(
+                selectedOption: StateValueSelectedOption(
+                    text: TextObject(type: .plainText, text: "*this is plain_text text*", emoji: true),
+                    value: "value-2"
+                )
+            )
+        )
+        XCTAssertEqual(radioGroup, radioGroupWithSelection)
+    }
+    
+    func test_radioGroup_withSelection_decode() throws {
+        let expectedRadioGroup = RadioButtonGroupStateValue(
+            selectedOption: StateValueSelectedOption(
+                text: TextObject(type: .plainText, text: "*this is plain_text text*", emoji: true),
+                value: "value-2"
+            )
+        )
+        let radioGroup = try jsonDecoder.decode(RadioButtonGroupStateValue.self, from: radioGroupWithSelection)
+        XCTAssertEqual(radioGroup, expectedRadioGroup)
+    }
+}

--- a/Tests/SlackBlockKitTests/StateValues/SelectMenuConversationsListStateValueTests.swift
+++ b/Tests/SlackBlockKitTests/StateValues/SelectMenuConversationsListStateValueTests.swift
@@ -1,21 +1,21 @@
 import SlackBlockKit
 import XCTest
 
-let selectConversationsNoSelection = """
+private let selectConversationsNoSelection = """
 {
   "selected_conversation" : null,
   "type" : "conversations_select"
 }
 """
 
-let selectConversationsWithSelection = """
+private let selectConversationsWithSelection = """
 {
   "selected_conversation" : "U01ERACBV43",
   "type" : "conversations_select"
 }
 """
 
-let selectConversationsWithUrlEnabled = """
+private let selectConversationsWithUrlEnabled = """
 {
   "response_url_enabled" : true,
   "selected_conversation" : "U01ERACBV43",

--- a/Tests/SlackBlockKitTests/StateValues/SelectMenuConversationsListStateValueTests.swift
+++ b/Tests/SlackBlockKitTests/StateValues/SelectMenuConversationsListStateValueTests.swift
@@ -1,0 +1,89 @@
+import SlackBlockKit
+import XCTest
+
+let selectConversationsNoSelection = """
+{
+  "selected_conversation" : null,
+  "type" : "conversations_select"
+}
+"""
+
+let selectConversationsWithSelection = """
+{
+  "selected_conversation" : "U01ERACBV43",
+  "type" : "conversations_select"
+}
+"""
+
+let selectConversationsWithUrlEnabled = """
+{
+  "response_url_enabled" : true,
+  "selected_conversation" : "U01ERACBV43",
+  "type" : "conversations_select"
+}
+"""
+
+class SelectMenuConversationsListStateValueTests: XCTestCase {
+    var jsonEncoder: JSONEncoder!
+    var jsonDecoder: JSONDecoder!
+    
+    override func setUp() {
+        jsonEncoder = JSONEncoder()
+        jsonEncoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        jsonDecoder = JSONDecoder()
+    }
+    
+    func test_selectConversations_noSelection_encode() throws {
+        let selectedConvo = try jsonEncoder.encodeAsString(
+            SelectMenuConversationsListStateValue(selectedConversation: nil)
+        )
+        XCTAssertEqual(selectedConvo, selectConversationsNoSelection)
+    }
+    
+    func test_selectConversations_noSelection_decode() throws {
+        let expectedSelectedConvo = SelectMenuConversationsListStateValue(selectedConversation: nil)
+        let selectedConvo = try jsonDecoder.decode(
+            SelectMenuConversationsListStateValue.self,
+            from: selectConversationsNoSelection
+        )
+        XCTAssertEqual(selectedConvo, expectedSelectedConvo)
+    }
+    
+    func test_selectConversations_withSelection_encode() throws {
+        let selectedConvo = try jsonEncoder.encodeAsString(
+            SelectMenuConversationsListStateValue(selectedConversation: "U01ERACBV43")
+        )
+        XCTAssertEqual(selectedConvo, selectConversationsWithSelection)
+    }
+    
+    func test_selectConversations_withSelection_decode() throws {
+        let expectedSelectedConvo = SelectMenuConversationsListStateValue(selectedConversation: "U01ERACBV43")
+        let selectedConvo = try jsonDecoder.decode(
+            SelectMenuConversationsListStateValue.self,
+            from: selectConversationsWithSelection
+        )
+        XCTAssertEqual(selectedConvo, expectedSelectedConvo)
+    }
+    
+    func test_selectConversations_withResponseUrl_encode() throws {
+        let selectedConvo = try jsonEncoder.encodeAsString(
+            SelectMenuConversationsListStateValue(
+                selectedConversation: "U01ERACBV43",
+                responseUrlEnabled: true
+            )
+        )
+        XCTAssertEqual(selectedConvo, selectConversationsWithUrlEnabled)
+    }
+    
+    func test_selectConversations_withResponseUrl_decode() throws {
+        let expectedSelectedConvo = SelectMenuConversationsListStateValue(
+            selectedConversation: "U01ERACBV43",
+            responseUrlEnabled: true
+        )
+        let selectedConvo = try jsonDecoder.decode(
+            SelectMenuConversationsListStateValue.self,
+            from: selectConversationsWithUrlEnabled
+        )
+        XCTAssertEqual(selectedConvo, expectedSelectedConvo)
+    }
+}

--- a/Tests/SlackBlockKitTests/StateValues/SelectMenuPublicChannelsListStateValueTests.swift
+++ b/Tests/SlackBlockKitTests/StateValues/SelectMenuPublicChannelsListStateValueTests.swift
@@ -1,0 +1,89 @@
+import SlackBlockKit
+import XCTest
+
+private let selectChannelsNoSelection = """
+{
+  "selected_channel" : null,
+  "type" : "channels_select"
+}
+"""
+
+private let selectChannelsWithSelection = """
+{
+  "selected_channel" : "C01EN1PHXFX",
+  "type" : "channels_select"
+}
+"""
+
+private let selectChannelsWithUrlEnabled = """
+{
+  "response_url_enabled" : true,
+  "selected_channel" : "C01EN1PHXFX",
+  "type" : "channels_select"
+}
+"""
+
+class SelectMenuPublicChannelsListStateValueTests: XCTestCase {
+    var jsonEncoder: JSONEncoder!
+    var jsonDecoder: JSONDecoder!
+    
+    override func setUp() {
+        jsonEncoder = JSONEncoder()
+        jsonEncoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        jsonDecoder = JSONDecoder()
+    }
+    
+    func test_selectConversations_noSelection_encode() throws {
+        let selectedChannel = try jsonEncoder.encodeAsString(
+            SelectMenuPublicChannelsListStateValue(selectedChannel: nil)
+        )
+        XCTAssertEqual(selectedChannel, selectChannelsNoSelection)
+    }
+    
+    func test_selectConversations_noSelection_decode() throws {
+        let expectedSelectedChannel = SelectMenuPublicChannelsListStateValue(selectedChannel: nil)
+        let selectedChannel = try jsonDecoder.decode(
+            SelectMenuPublicChannelsListStateValue.self,
+            from: selectChannelsNoSelection
+        )
+        XCTAssertEqual(selectedChannel, expectedSelectedChannel)
+    }
+    
+    func test_selectConversations_withSelection_encode() throws {
+        let selectedChannel = try jsonEncoder.encodeAsString(
+            SelectMenuPublicChannelsListStateValue(selectedChannel: "C01EN1PHXFX")
+        )
+        XCTAssertEqual(selectedChannel, selectChannelsWithSelection)
+    }
+    
+    func test_selectConversations_withSelection_decode() throws {
+        let expectedSelectedChannel = SelectMenuPublicChannelsListStateValue(selectedChannel: "C01EN1PHXFX")
+        let selectedChannel = try jsonDecoder.decode(
+            SelectMenuPublicChannelsListStateValue.self,
+            from: selectChannelsWithSelection
+        )
+        XCTAssertEqual(selectedChannel, expectedSelectedChannel)
+    }
+    
+    func test_selectConversations_withResponseUrl_encode() throws {
+        let selectedChannel = try jsonEncoder.encodeAsString(
+            SelectMenuPublicChannelsListStateValue(
+                selectedChannel: "C01EN1PHXFX",
+                responseUrlEnabled: true
+            )
+        )
+        XCTAssertEqual(selectedChannel, selectChannelsWithUrlEnabled)
+    }
+    
+    func test_selectConversations_withResponseUrl_decode() throws {
+        let expectedSelectedChannel = SelectMenuPublicChannelsListStateValue(
+            selectedChannel: "C01EN1PHXFX",
+            responseUrlEnabled: true
+        )
+        let selectedChannel = try jsonDecoder.decode(
+            SelectMenuPublicChannelsListStateValue.self,
+            from: selectChannelsWithUrlEnabled
+        )
+        XCTAssertEqual(selectedChannel, expectedSelectedChannel)
+    }
+}

--- a/Tests/SlackBlockKitTests/StateValues/SelectMenuStaticOptionsStateValueTests.swift
+++ b/Tests/SlackBlockKitTests/StateValues/SelectMenuStaticOptionsStateValueTests.swift
@@ -1,0 +1,71 @@
+import SlackBlockKit
+import XCTest
+
+private let selectMenuNoSelection = """
+{
+  "selected_option" : null,
+  "type" : "static_select"
+}
+"""
+
+private let selectMenuWithSelection = """
+{
+  "selected_option" : {
+    "text" : {
+      "text" : "*this is plain_text text*",
+      "type" : "plain_text"
+    },
+    "value" : "value-0"
+  },
+  "type" : "static_select"
+}
+"""
+
+class SelectMenuStaticOptionsStateValueTests: XCTestCase {
+    var jsonEncoder: JSONEncoder!
+    var jsonDecoder: JSONDecoder!
+    
+    override func setUp() {
+        jsonEncoder = JSONEncoder()
+        jsonEncoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        jsonDecoder = JSONDecoder()
+    }
+    
+    func test_selectMenu_noSelection_encode() throws {
+        let selection = SelectMenuStaticOptionsStateValue(selectedOption: nil)
+        try XCTAssertEqual(jsonEncoder.encodeAsString(selection), selectMenuNoSelection)
+    }
+    
+    func test_selectMenu_noSelection_decode() throws {
+        let expectedSelection = SelectMenuStaticOptionsStateValue(selectedOption: nil)
+        let selection = try jsonDecoder.decode(
+            SelectMenuStaticOptionsStateValue.self,
+            from: selectMenuNoSelection
+        )
+        XCTAssertEqual(selection, expectedSelection)
+    }
+    
+    func test_selectMenu_withSelection_encode() throws {
+        let selection = SelectMenuStaticOptionsStateValue(
+            selectedOption: StateValueSelectedOption(
+                text: TextObject(type: .plainText, text: "*this is plain_text text*"),
+                value: "value-0"
+            )
+        )
+        try XCTAssertEqual(jsonEncoder.encodeAsString(selection), selectMenuWithSelection)
+    }
+    
+    func test_selectMenu_withSelection_decode() throws {
+        let expectedSelection = SelectMenuStaticOptionsStateValue(
+            selectedOption: StateValueSelectedOption(
+                text: TextObject(type: .plainText, text: "*this is plain_text text*"),
+                value: "value-0"
+            )
+        )
+        let selection = try jsonDecoder.decode(
+            SelectMenuStaticOptionsStateValue.self,
+            from: selectMenuWithSelection
+        )
+        XCTAssertEqual(selection, expectedSelection)
+    }
+}

--- a/Tests/SlackBlockKitTests/StateValues/SelectMenuUserListStateValueTests.swift
+++ b/Tests/SlackBlockKitTests/StateValues/SelectMenuUserListStateValueTests.swift
@@ -1,0 +1,59 @@
+import SlackBlockKit
+import XCTest
+
+private let selectUserNoSelection = """
+{
+  "selected_user" : null,
+  "type" : "users_select"
+}
+"""
+
+private let selectUserWithSelection = """
+{
+  "selected_user" : "U01ERACBV43",
+  "type" : "users_select"
+}
+"""
+
+class SelectMenuUserListStateValueTests: XCTestCase {
+    var jsonEncoder: JSONEncoder!
+    var jsonDecoder: JSONDecoder!
+    
+    override func setUp() {
+        jsonEncoder = JSONEncoder()
+        jsonEncoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        jsonDecoder = JSONDecoder()
+    }
+    
+    func test_selectConversations_noSelection_encode() throws {
+        let selectedUser = try jsonEncoder.encodeAsString(
+            SelectMenuUserListStateValue(selectedUser: nil)
+        )
+        XCTAssertEqual(selectedUser, selectUserNoSelection)
+    }
+    
+    func test_selectConversations_noSelection_decode() throws {
+        let expectedSelectedUser = SelectMenuUserListStateValue(selectedUser: nil)
+        let selectedUser = try jsonDecoder.decode(
+            SelectMenuUserListStateValue.self,
+            from: selectUserNoSelection
+        )
+        XCTAssertEqual(selectedUser, expectedSelectedUser)
+    }
+    
+    func test_selectConversations_withSelection_encode() throws {
+        let selectedUser = try jsonEncoder.encodeAsString(
+            SelectMenuUserListStateValue(selectedUser: "U01ERACBV43")
+        )
+        XCTAssertEqual(selectedUser, selectUserWithSelection)
+    }
+    
+    func test_selectConversations_withSelection_decode() throws {
+        let expectedSelectedUser = SelectMenuUserListStateValue(selectedUser: "U01ERACBV43")
+        let selectedUser = try jsonDecoder.decode(
+            SelectMenuUserListStateValue.self,
+            from: selectUserWithSelection
+        )
+        XCTAssertEqual(selectedUser, expectedSelectedUser)
+    }
+}

--- a/Tests/SlackBlockKitTests/StateValues/TimePickerStateValueTests.swift
+++ b/Tests/SlackBlockKitTests/StateValues/TimePickerStateValueTests.swift
@@ -1,0 +1,23 @@
+import SlackBlockKit
+import XCTest
+
+private let timePicker = """
+{
+  "selected_time": "13:37",
+  "type": "timepicker"
+}
+"""
+
+class TimePickerStateValueTests: XCTestCase {
+    private var jsonDecoder: JSONDecoder!
+    
+    override func setUp() {
+        jsonDecoder = JSONDecoder()
+    }
+    
+    func test_timePicker() throws {
+        let timePickerState = try jsonDecoder.decode(TimePickerStateValue.self, from: timePicker)
+        let expectedTimePicker = TimePickerStateValue(selectedTime: "13:37")
+        XCTAssertEqual(timePickerState, expectedTimePicker)
+    }
+}

--- a/Tests/SlackBlockKitTests/TestUtils/AssertJSONEqual.swift
+++ b/Tests/SlackBlockKitTests/TestUtils/AssertJSONEqual.swift
@@ -20,7 +20,12 @@ func AssertJSONEqual(
         let lhsJSONData = try JSONSerialization.data(withJSONObject: lhsJSONObject, options: .sortedKeys)
         let rhsJSONObject = try JSONSerialization.jsonObject(with: rhsData)
         let rhsJSONData = try JSONSerialization.data(withJSONObject: rhsJSONObject, options: .sortedKeys)
-        XCTAssertEqual(lhsJSONData, rhsJSONData, file: file, line: line)
+        
+        guard let lhsJSONString = String(data: lhsJSONData, encoding: .utf8), let rhsJSONString = String(data: rhsJSONData, encoding: .utf8) else {
+            return XCTFail("JSON serialized data was not convertible to String", file: file, line: line)
+        }
+        
+        XCTAssertEqual(lhsJSONString, rhsJSONString, file: file, line: line)
     } catch {
         XCTFail("Problem decoding/encoding JSON: \(error.localizedDescription)", file: file, line: line)
     }

--- a/Tests/SlackBlockKitTests/TestUtils/BlockTestCase.swift
+++ b/Tests/SlackBlockKitTests/TestUtils/BlockTestCase.swift
@@ -63,4 +63,22 @@ class BlockTestCase: XCTestCase {
             XCTFail(error.localizedDescription)
         }
     }
+    
+    func testCodableEquality<EventType: SlackEvent & Equatable>(
+        event: EventType,
+        jsonString: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        do {
+            // test encode
+            let json = try jsonEncoder.encodeAsString(event)
+            AssertJSONEqual(json, jsonString)
+            // test decode
+            let actualEvent = try jsonDecoder.decode(Swift.type(of: event), from: jsonString)
+            XCTAssertEqual(event, actualEvent)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
 }

--- a/Tests/SlackBlockKitTests/TestUtils/BlockTestCase.swift
+++ b/Tests/SlackBlockKitTests/TestUtils/BlockTestCase.swift
@@ -81,4 +81,22 @@ class BlockTestCase: XCTestCase {
             XCTFail(error.localizedDescription)
         }
     }
+    
+    func testCodableEquality<EventWrapperType: SlackEventWrapper & Equatable>(
+        event: EventWrapperType,
+        jsonString: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        do {
+            // test encode
+            let json = try jsonEncoder.encodeAsString(event)
+            AssertJSONEqual(json, jsonString)
+            // test decode
+            let actualEvent = try jsonDecoder.decode(Swift.type(of: event), from: jsonString)
+            XCTAssertEqual(event, actualEvent)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
 }

--- a/Tests/SlackBlockKitTests/Views/HomeTabViewTests.swift
+++ b/Tests/SlackBlockKitTests/Views/HomeTabViewTests.swift
@@ -37,6 +37,103 @@ private let homeTabView = """
 }
 """
 
+private let homeTabViewWithState = """
+{
+  "type": "home",
+  "blocks": [
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "Example built using `app.slack.com/block-kit-builder`"
+      }
+    },
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "This is a section block with checkboxes."
+      },
+      "accessory": {
+        "type": "checkboxes",
+        "options": [
+          {
+            "text": {
+              "type": "mrkdwn",
+              "text": "*this is mrkdwn text*"
+            },
+            "description": {
+              "type": "mrkdwn",
+              "text": "*this is mrkdwn text*"
+            },
+            "value": "value-0"
+          },
+          {
+            "text": {
+              "type": "mrkdwn",
+              "text": "*this is mrkdwn text*"
+            },
+            "description": {
+              "type": "mrkdwn",
+              "text": "*this is mrkdwn text*"
+            },
+            "value": "value-1"
+          }
+        ],
+        "action_id": "checkboxes-action"
+      }
+    },
+    {
+      "type": "input",
+      "element": {
+        "type": "multi_users_select",
+        "placeholder": {
+          "type": "plain_text",
+          "text": "Select users"
+        },
+        "action_id": "multi_users_select-action"
+      },
+      "label": {
+        "type": "plain_text",
+        "text": "Label"
+      }
+    }
+  ],
+  "state": {
+    "values": {
+      "5GC": {
+        "multi_users_select-action": {
+          "type": "multi_users_select",
+          "selected_users": [
+            "U01ERACBV43"
+          ]
+        }
+      },
+      "zS3q": {
+        "checkboxes-action": {
+          "type": "checkboxes",
+          "selected_options": [
+            {
+              "text": {
+                "type": "mrkdwn",
+                "text": "*this is mrkdwn text*",
+                "verbatim": false
+              },
+              "value": "value-0",
+              "description": {
+                "type": "mrkdwn",
+                "text": "*this is mrkdwn text*",
+                "verbatim": false
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+"""
+
 class HomeTabViewTests: BlockTestCase {
     func test_homeTabView() {
         let expectedHomeTab = HomeTabView(
@@ -68,5 +165,67 @@ class HomeTabViewTests: BlockTestCase {
             ]
         )
         testCodableEquality(view: expectedHomeTab, jsonString: homeTabView)
+    }
+    
+    func test_homeTabViewWithState() {
+        var expectedHomeTab = HomeTabView(
+            blocks: [
+                SectionBlock(
+                    text: TextObject(
+                        type: .mrkdwn,
+                        text: "Example built using `app.slack.com/block-kit-builder`"
+                    )
+                ),
+                SectionBlock(
+                    text: TextObject(
+                        type: .mrkdwn,
+                        text: "This is a section block with checkboxes."
+                    ),
+                    accessory: CheckboxGroups(
+                        actionId: "checkboxes-action",
+                        options: [
+                            OptionObject(
+                                text: TextObject(type: .mrkdwn, text: "*this is mrkdwn text*"),
+                                value: "value-0",
+                                description: TextObject(type: .mrkdwn, text: "*this is mrkdwn text*")
+                            ),
+                            OptionObject(
+                                text: TextObject(type: .mrkdwn, text: "*this is mrkdwn text*"),
+                                value: "value-1",
+                                description: TextObject(type: .mrkdwn, text: "*this is mrkdwn text*")
+                            )
+                        ]
+                    )
+                ),
+                InputBlock(
+                    label: TextObject(type: .plainText, text: "Label"),
+                    element: MultiSelectMenuUserList(
+                        placeholder: TextObject(type: .plainText, text: "Select users"),
+                        actionId: "multi_users_select-action"
+                    )
+                )
+            ]
+        )
+        expectedHomeTab.state = ViewState(
+            values: [
+                "5GC": [
+                    "multi_users_select-action": MultiSelectMenuUserListStateValue(
+                        selectedUsers: ["U01ERACBV43"]
+                    )
+                ],
+                "zS3q": [
+                    "checkboxes-action": CheckboxGroupsStateValue(
+                        selectedOptions: [
+                            StateValueSelectedOption(
+                                text: TextObject(type: .mrkdwn, text: "*this is mrkdwn text*", verbatim: false),
+                                value: "value-0",
+                                description: TextObject(type: .mrkdwn, text: "*this is mrkdwn text*", verbatim: false)
+                            )
+                        ]
+                    )
+                ]
+            ]
+        )
+        testCodableEquality(view: expectedHomeTab, jsonString: homeTabViewWithState)
     }
 }

--- a/Tests/SlackBlockKitTests/Views/HomeTabViewTests.swift
+++ b/Tests/SlackBlockKitTests/Views/HomeTabViewTests.swift
@@ -99,6 +99,7 @@ private let homeTabViewWithState = """
       }
     }
   ],
+  "hash": "12345",
   "state": {
     "values": {
       "5GC": {
@@ -226,6 +227,7 @@ class HomeTabViewTests: BlockTestCase {
                 ]
             ]
         )
+        expectedHomeTab.hash = "12345"
         testCodableEquality(view: expectedHomeTab, jsonString: homeTabViewWithState)
     }
 }

--- a/Tests/SlackBlockKitTests/Views/ModalViewTests.swift
+++ b/Tests/SlackBlockKitTests/Views/ModalViewTests.swift
@@ -54,13 +54,14 @@ private let modalView = """
     "text": "Save"
   },
   "private_metadata": "Shhhhhhhh",
-  "callback_id": "view_identifier_12"
+  "callback_id": "view_identifier_12",
+  "hash": "12345"
 }
 """
 
 class ModalViewTests: BlockTestCase {
     func test_modalView() {
-        let expectedModal = ModalView(
+        var expectedModal = ModalView(
             title: TextObject(type: .plainText, text: "Modal title"),
             blocks: [
                 SectionBlock(
@@ -91,6 +92,7 @@ class ModalViewTests: BlockTestCase {
             privateMetadata: "Shhhhhhhh",
             callbackId: "view_identifier_12"
         )
+        expectedModal.hash = "12345"
         testCodableEquality(view: expectedModal, jsonString: modalView)
     }
 }


### PR DESCRIPTION
The scope of this PR is to introduce the Slack event structure that can be used for later expansion. At the moment, only the "app home opened" event will be added, as it is in line with the [App Home Demo app](https://api.slack.com/tutorials/app-home-with-modal) that I am implementing in Swift separately (with Swift AWS Lambda runtime) to test a lot of this functionality.