### PR TITLE
Date and time strong types

### DIFF
--- a/Sources/SlackBlockKit/BlockElements/DatePickerElement.swift
+++ b/Sources/SlackBlockKit/BlockElements/DatePickerElement.swift
@@ -18,7 +18,7 @@ public struct DatePickerElement: BlockElement, ActionsBlockElement, InputBlockEl
     public let placeholder: TextObject?
     /// The initial date that is selected when the element is loaded. This should be
     /// in the format `YYYY-MM-DD`.
-    public let initialDate: String?
+    public let initialDate: SlackDate?
     /// A confirm object that defines an optional confirmation dialog that appears
     /// after a date is selected.
     public let confirm: ConfirmationDialogObject?
@@ -26,7 +26,7 @@ public struct DatePickerElement: BlockElement, ActionsBlockElement, InputBlockEl
     public init(
         actionId: String,
         placeholder: TextObject? = nil,
-        initialDate: String? = nil,
+        initialDate: SlackDate? = nil,
         confirm: ConfirmationDialogObject? = nil
     ) {
         self.type = Self.type.rawValue

--- a/Sources/SlackBlockKit/BlockElements/UtilTypes/SlackDate.swift
+++ b/Sources/SlackBlockKit/BlockElements/UtilTypes/SlackDate.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// A representation of a date that can be used with a Slack `DatePickerElement`.
+public struct SlackDate: Codable, Equatable {
+    public let year: UInt
+    public let month: UInt
+    public let day: UInt
+    
+    public init(year: UInt, month: UInt, day: UInt) {
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+        let dateComponents = dateString.split(separator: "-")
+        guard dateComponents.count == 3 else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Invalid date structure: date not split into 3 components by `-` separator."
+            )
+        }
+        guard let year = UInt(dateComponents[0]) else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Invalid date structure: year component not valid Int."
+            )
+        }
+        guard let month = UInt(dateComponents[1]) else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Invalid date structure: month component not valid Int."
+            )
+        }
+        guard let day = UInt(dateComponents[2]) else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Invalid date structure: day component not valid Int."
+            )
+        }
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(String(format: "%04u-%02u-%02u", year, month, day))
+    }
+}

--- a/Sources/SlackBlockKit/StateValues/DatePickerStateValue.swift
+++ b/Sources/SlackBlockKit/StateValues/DatePickerStateValue.swift
@@ -1,9 +1,9 @@
 public struct DatePickerStateValue: StateValue, Equatable {
     public static let type: StateValueType = .datepicker
     public let type: String
-    public let selectedDate: String
+    public let selectedDate: SlackDate
     
-    public init(selectedDate: String) {
+    public init(selectedDate: SlackDate) {
         self.type = Self.type.rawValue
         self.selectedDate = selectedDate
     }

--- a/Tests/SlackBlockKitTests/BlockElements/DatePickerElementTests.swift
+++ b/Tests/SlackBlockKitTests/BlockElements/DatePickerElementTests.swift
@@ -21,7 +21,7 @@ class DatePickerElementTests: BlockTestCase {
                 type: .plainText,
                 text: "Select a date"
             ),
-            initialDate: "1990-04-28"
+            initialDate: SlackDate(year: 1990, month: 4, day: 28)
         )
         testCodableEquality(block: expectedDatePicker, jsonString: datePickerElement)
     }

--- a/Tests/SlackBlockKitTests/BlockElements/SlackDateTests.swift
+++ b/Tests/SlackBlockKitTests/BlockElements/SlackDateTests.swift
@@ -1,0 +1,118 @@
+import SlackBlockKit
+import XCTest
+
+class SlackDateTests: XCTestCase {
+    var jsonEncoder: JSONEncoder!
+    var jsonDecoder: JSONDecoder!
+    
+    override func setUp() {
+        jsonEncoder = JSONEncoder()
+        jsonDecoder = JSONDecoder()
+    }
+    
+    func test_date_valid_decode() throws {
+        let expectedDate = SlackDate(year: 2021, month: 1, day: 14)
+        let actualDate = try decodeDate(from: "2021-01-14")
+        XCTAssertEqual(expectedDate, actualDate)
+    }
+    
+    func test_date_valid_encode() throws {
+        let expectedDate = dateStringJSON(forDateString: "1991-03-30")
+        let date = SlackDate(year: 1991, month: 3, day: 30)
+        try XCTAssertEqual(expectedDate, encodeDateAsString(date: date))
+    }
+    
+    func test_date_earliestDay_decode() throws {
+        let expectedDate = SlackDate(year: 0, month: 1, day: 1)
+        let actualDate = try decodeDate(from: "0000-01-01")
+        XCTAssertEqual(expectedDate, actualDate)
+    }
+    
+    func test_date_earliestDay_encode() throws {
+        let expectedDate = dateStringJSON(forDateString: "0000-01-01")
+        let date = SlackDate(year: 0, month: 1, day: 1)
+        try XCTAssertEqual(expectedDate, encodeDateAsString(date: date))
+    }
+    
+    func test_date_invalid_wrongSeparators() {
+        XCTAssertThrowsError(try decodeDate(from: "2021:01:14")) { error in
+            guard let decodingError = error as? DecodingError else { return XCTFail() }
+            switch decodingError {
+            case .dataCorrupted(let context):
+                XCTAssertEqual(context.debugDescription, "Invalid date structure: date not split into 3 components by `-` separator.")
+            default:
+                XCTFail()
+            }
+        }
+    }
+    
+    func test_date_invalid_incorrectNumberOfSeparators() {
+        XCTAssertThrowsError(try decodeDate(from: "2021-01")) { error in
+            guard let decodingError = error as? DecodingError else { return XCTFail() }
+            switch decodingError {
+            case .dataCorrupted(let context):
+                XCTAssertEqual(context.debugDescription, "Invalid date structure: date not split into 3 components by `-` separator.")
+            default:
+                XCTFail()
+            }
+        }
+    }
+    
+    func test_date_invalid_yearNotNumber() {
+        XCTAssertThrowsError(try decodeDate(from: "twentytwentyone-01-14")) { error in
+            guard let decodingError = error as? DecodingError else { return XCTFail() }
+            switch decodingError {
+            case .dataCorrupted(let context):
+                XCTAssertEqual(context.debugDescription, "Invalid date structure: year component not valid Int.")
+            default:
+                XCTFail()
+            }
+        }
+    }
+    
+    func test_date_invalid_monthNotNumber() {
+        XCTAssertThrowsError(try decodeDate(from: "2021-jan-14")) { error in
+            guard let decodingError = error as? DecodingError else { return XCTFail() }
+            switch decodingError {
+            case .dataCorrupted(let context):
+                XCTAssertEqual(context.debugDescription, "Invalid date structure: month component not valid Int.")
+            default:
+                XCTFail()
+            }
+        }
+    }
+    
+    func test_date_invalid_dayNotNumber() {
+        XCTAssertThrowsError(try decodeDate(from: "2021-01-fourteenth")) { error in
+            guard let decodingError = error as? DecodingError else { return XCTFail() }
+            switch decodingError {
+            case .dataCorrupted(let context):
+                XCTAssertEqual(context.debugDescription, "Invalid date structure: day component not valid Int.")
+            default:
+                XCTFail()
+            }
+        }
+    }
+}
+
+extension SlackDateTests {
+    fileprivate struct TestHelperJSON: Codable, Equatable {
+        let date: SlackDate
+    }
+    
+    fileprivate func decodeDate(from: String) throws -> SlackDate {
+        return try jsonDecoder.decode(TestHelperJSON.self, from: dateStringJSON(forDateString: from)).date
+    }
+    
+    fileprivate func encodeDateAsString(date: SlackDate) throws -> String {
+        return try jsonEncoder.encodeAsString(dateTestHelper(forDate: date))
+    }
+    
+    private func dateStringJSON(forDateString dateString: String) -> String {
+        return "{\"date\":\"\(dateString)\"}"
+    }
+    
+    private func dateTestHelper(forDate date: SlackDate) -> TestHelperJSON {
+        return TestHelperJSON(date: date)
+    }
+}

--- a/Tests/SlackBlockKitTests/StateValues/DatePickerStateValueTests.swift
+++ b/Tests/SlackBlockKitTests/StateValues/DatePickerStateValueTests.swift
@@ -17,7 +17,7 @@ class DatePickerStateValueTests: XCTestCase {
     
     func test_datePicker() throws {
         let datePickerState = try jsonDecoder.decode(DatePickerStateValue.self, from: datePicker)
-        let expectedDatePicker = DatePickerStateValue(selectedDate: "1990-04-28")
+        let expectedDatePicker = DatePickerStateValue(selectedDate: SlackDate(year: 1990, month: 4, day: 28))
         XCTAssertEqual(datePickerState, expectedDatePicker)
     }
 }


### PR DESCRIPTION
There is an expected format for dates in Slack Block Kit and so this PR formalises that with strong typing.